### PR TITLE
use media type as source of truth instead of type

### DIFF
--- a/services/content-publishing/apps/worker/src/request_processor/dsnp.announcement.processor.ts
+++ b/services/content-publishing/apps/worker/src/request_processor/dsnp.announcement.processor.ts
@@ -236,17 +236,18 @@ export class DsnpAnnouncementProcessor {
     const attachments: ActivityContentAttachment[] = [];
     if (assetData) {
       const promises = assetData.map(async (asset) => {
-        switch (asset.type) {
-          case AttachmentTypeDto.LINK:
+        const mediaType = asset.url[0].mediaType;
+        switch (asset.url[0].mediaType) {
+          case mediaType.startsWith(AttachmentTypeDto.LINK):
             attachments.push(this.prepareLinkAttachment(asset));
             break;
-          case AttachmentTypeDto.IMAGE:
+          case mediaType.startsWith(AttachmentTypeDto.IMAGE):
             attachments.push(await this.prepareImageAttachment(asset, assetToMimeType));
             break;
-          case AttachmentTypeDto.VIDEO:
+          case mediaType.startsWith(AttachmentTypeDto.VIDEO):
             attachments.push(await this.prepareVideoAttachment(asset, assetToMimeType));
             break;
-          case AttachmentTypeDto.AUDIO:
+          case mediaType.startsWith(AttachmentTypeDto.AUDIO):
             attachments.push(await this.prepareAudioAttachment(asset, assetToMimeType));
             break;
           default:


### PR DESCRIPTION
# Problem
Need to use `mediaType` as the source of truth instead of `type` when handling assets

Link to GitHub Issue(s): 

# Solution
instead of handling an asset based on the type in the backed, the switch statement cases have been changed to handle the data based on mediaType. 

with @JoeCap08055 

## Steps to Verify:

1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

## Screenshots (optional):

Show-n-tell images/animations here
