### PR TITLE
[bug] content-publisher needs to be its own source of truth for announcement attachments 

### DIFF
--- a/services/content-publishing/README.md
+++ b/services/content-publishing/README.md
@@ -167,27 +167,16 @@ Use the provided [env.template](./env.template) file to create an initial enviro
 
   ```sh
   cp env.template .env 
-  cp env.template .env.docker.dev
   ```
 
   2. Configure the environment variable values according to your environment.
-
-### Setup
-
-Clone this repository to your desired folder:
-
-Example commands:
-
-```sh
-  git clone git@github.com:AmplicaLabs/content-publishing-service.git
-  cd content-publishing-service
-```
 
 ### Install
 
 Install NPM Dependencies:
 
 ```sh
+  cd services/content-publishing
   npm install
 ```
 

--- a/services/content-publishing/apps/api/src/metadata.ts
+++ b/services/content-publishing/apps/api/src/metadata.ts
@@ -1,8 +1,93 @@
 /* eslint-disable */
 export default async () => {
-    const t = {
-        ["../../../libs/common/src/dtos/activity.dto"]: await import("../../../libs/common/src/dtos/activity.dto"),
-        ["../../../libs/common/src/dtos/announcement.dto"]: await import("../../../libs/common/src/dtos/announcement.dto")
-    };
-    return { "@nestjs/swagger": { "models": [[import("../../../libs/common/src/dtos/common.dto"), { "DsnpUserIdParam": { userDsnpId: { required: true, type: () => String } }, "AnnouncementResponseDto": { referenceId: { required: true, type: () => String } }, "UploadResponseDto": { assetIds: { required: true, type: () => [String] } }, "FilesUploadDto": { files: { required: true, type: () => [Object] } } }], [import("../../../libs/common/src/dtos/activity.dto"), { "LocationDto": { name: { required: true, type: () => String, minLength: 1 }, accuracy: { required: false, type: () => Number, minimum: 0, maximum: 100 }, altitude: { required: false, type: () => Number }, latitude: { required: false, type: () => Number }, longitude: { required: false, type: () => Number }, radius: { required: false, type: () => Number, minimum: 0 }, units: { required: false, enum: t["../../../libs/common/src/dtos/activity.dto"].UnitTypeDto } }, "AssetReferenceDto": { referenceId: { required: true, type: () => String, minLength: 1 }, height: { required: false, type: () => Number, minimum: 1 }, width: { required: false, type: () => Number, minimum: 1 }, duration: { required: false, type: () => String, pattern: "DURATION_REGEX" } }, "TagDto": { type: { required: true, enum: t["../../../libs/common/src/dtos/activity.dto"].TagTypeDto }, name: { required: false, type: () => String, minLength: 1 }, mentionedId: { required: false, type: () => String } }, "AssetDto": { type: { required: true, enum: t["../../../libs/common/src/dtos/activity.dto"].AttachmentTypeDto }, references: { required: false, type: () => [t["../../../libs/common/src/dtos/activity.dto"].AssetReferenceDto] }, name: { required: false, type: () => String, minLength: 1 }, href: { required: false, type: () => String, minLength: 1 } }, "BaseActivityDto": { name: { required: false, type: () => String }, tag: { required: false, type: () => [t["../../../libs/common/src/dtos/activity.dto"].TagDto] }, location: { required: false, type: () => t["../../../libs/common/src/dtos/activity.dto"].LocationDto } }, "NoteActivityDto": { content: { required: true, type: () => String, minLength: 1 }, published: { required: true, type: () => String }, assets: { required: false, type: () => [t["../../../libs/common/src/dtos/activity.dto"].AssetDto] } }, "ProfileActivityDto": { icon: { required: false, type: () => [t["../../../libs/common/src/dtos/activity.dto"].AssetReferenceDto] }, summary: { required: false, type: () => String }, published: { required: false, type: () => String } } }], [import("../../../libs/common/src/dtos/announcement.dto"), { "BroadcastDto": { content: { required: true, type: () => t["../../../libs/common/src/dtos/activity.dto"].NoteActivityDto } }, "ReplyDto": { inReplyTo: { required: true, type: () => String }, content: { required: true, type: () => t["../../../libs/common/src/dtos/activity.dto"].NoteActivityDto } }, "TombstoneDto": { targetContentHash: { required: true, type: () => String }, targetAnnouncementType: { required: true, enum: t["../../../libs/common/src/dtos/announcement.dto"].ModifiableAnnouncementTypeDto } }, "UpdateDto": { targetContentHash: { required: true, type: () => String }, targetAnnouncementType: { required: true, enum: t["../../../libs/common/src/dtos/announcement.dto"].ModifiableAnnouncementTypeDto }, content: { required: true, type: () => t["../../../libs/common/src/dtos/activity.dto"].NoteActivityDto } }, "ReactionDto": { emoji: { required: true, type: () => String, minLength: 1, pattern: "DSNP_EMOJI_REGEX" }, apply: { required: true, type: () => Number, minimum: 0, maximum: 255 }, inReplyTo: { required: true, type: () => String } }, "ProfileDto": { profile: { required: true, type: () => t["../../../libs/common/src/dtos/activity.dto"].ProfileActivityDto } } }]], "controllers": [[import("./controllers/health.controller"), { "HealthController": { "healthz": {}, "livez": {}, "readyz": {} } }]] } };
+  const t = {
+    ['../../../libs/common/src/dtos/activity.dto']: await import('../../../libs/common/src/dtos/activity.dto'),
+    ['../../../libs/common/src/dtos/announcement.dto']: await import('../../../libs/common/src/dtos/announcement.dto'),
+  };
+  return {
+    '@nestjs/swagger': {
+      models: [
+        [
+          import('../../../libs/common/src/dtos/common.dto'),
+          {
+            DsnpUserIdParam: { userDsnpId: { required: true, type: () => String } },
+            AnnouncementResponseDto: { referenceId: { required: true, type: () => String } },
+            UploadResponseDto: { assetIds: { required: true, type: () => [String] } },
+            FilesUploadDto: { files: { required: true, type: () => [Object] } },
+          },
+        ],
+        [
+          import('../../../libs/common/src/dtos/activity.dto'),
+          {
+            LocationDto: {
+              name: { required: true, type: () => String, minLength: 1 },
+              accuracy: { required: false, type: () => Number, minimum: 0, maximum: 100 },
+              altitude: { required: false, type: () => Number },
+              latitude: { required: false, type: () => Number },
+              longitude: { required: false, type: () => Number },
+              radius: { required: false, type: () => Number, minimum: 0 },
+              units: { required: false, enum: t['../../../libs/common/src/dtos/activity.dto'].UnitTypeDto },
+            },
+            AssetReferenceDto: {
+              referenceId: { required: true, type: () => String, minLength: 1 },
+              height: { required: false, type: () => Number, minimum: 1 },
+              width: { required: false, type: () => Number, minimum: 1 },
+              duration: { required: false, type: () => String, pattern: 'DURATION_REGEX' },
+            },
+            TagDto: {
+              type: { required: true, enum: t['../../../libs/common/src/dtos/activity.dto'].TagTypeDto },
+              name: { required: false, type: () => String, minLength: 1 },
+              mentionedId: { required: false, type: () => String },
+            },
+            AssetDto: {
+              references: { required: false, type: () => [t['../../../libs/common/src/dtos/activity.dto'].AssetReferenceDto] },
+              name: { required: false, type: () => String, minLength: 1 },
+              href: { required: false, type: () => String, minLength: 1 },
+            },
+            BaseActivityDto: {
+              name: { required: false, type: () => String },
+              tag: { required: false, type: () => [t['../../../libs/common/src/dtos/activity.dto'].TagDto] },
+              location: { required: false, type: () => t['../../../libs/common/src/dtos/activity.dto'].LocationDto },
+            },
+            NoteActivityDto: {
+              content: { required: true, type: () => String, minLength: 1 },
+              published: { required: true, type: () => String },
+              assets: { required: false, type: () => [t['../../../libs/common/src/dtos/activity.dto'].AssetDto] },
+            },
+            ProfileActivityDto: {
+              icon: { required: false, type: () => [t['../../../libs/common/src/dtos/activity.dto'].AssetReferenceDto] },
+              summary: { required: false, type: () => String },
+              published: { required: false, type: () => String },
+            },
+          },
+        ],
+        [
+          import('../../../libs/common/src/dtos/announcement.dto'),
+          {
+            BroadcastDto: { content: { required: true, type: () => t['../../../libs/common/src/dtos/activity.dto'].NoteActivityDto } },
+            ReplyDto: {
+              inReplyTo: { required: true, type: () => String },
+              content: { required: true, type: () => t['../../../libs/common/src/dtos/activity.dto'].NoteActivityDto },
+            },
+            TombstoneDto: {
+              targetContentHash: { required: true, type: () => String },
+              targetAnnouncementType: { required: true, enum: t['../../../libs/common/src/dtos/announcement.dto'].ModifiableAnnouncementTypeDto },
+            },
+            UpdateDto: {
+              targetContentHash: { required: true, type: () => String },
+              targetAnnouncementType: { required: true, enum: t['../../../libs/common/src/dtos/announcement.dto'].ModifiableAnnouncementTypeDto },
+              content: { required: true, type: () => t['../../../libs/common/src/dtos/activity.dto'].NoteActivityDto },
+            },
+            ReactionDto: {
+              emoji: { required: true, type: () => String, minLength: 1, pattern: 'DSNP_EMOJI_REGEX' },
+              apply: { required: true, type: () => Number, minimum: 0, maximum: 255 },
+              inReplyTo: { required: true, type: () => String },
+            },
+            ProfileDto: { profile: { required: true, type: () => t['../../../libs/common/src/dtos/activity.dto'].ProfileActivityDto } },
+          },
+        ],
+      ],
+      controllers: [[import('./controllers/health.controller'), { HealthController: { healthz: {}, livez: {}, readyz: {} } }]],
+    },
+  };
 };

--- a/services/content-publishing/apps/worker/src/request_processor/dsnp.announcement.processor.ts
+++ b/services/content-publishing/apps/worker/src/request_processor/dsnp.announcement.processor.ts
@@ -24,8 +24,9 @@ import {
   TombstoneDto,
   ModifiableAnnouncementTypeDto,
   TagTypeDto,
-  AttachmentTypeDto,
+  AttachmentType,
   AssetDto,
+  TagDto,
 } from '#libs/dtos';
 import {
   IRequestJob,
@@ -43,14 +44,7 @@ import {
   ProfileAnnouncement,
   createProfile,
 } from '#libs/interfaces';
-import {
-  BROADCAST_QUEUE_NAME,
-  REPLY_QUEUE_NAME,
-  REACTION_QUEUE_NAME,
-  UPDATE_QUEUE_NAME,
-  PROFILE_QUEUE_NAME,
-  TOMBSTONE_QUEUE_NAME,
-} from '#libs/queues/queue.constants';
+import { BROADCAST_QUEUE_NAME, REPLY_QUEUE_NAME, REACTION_QUEUE_NAME, UPDATE_QUEUE_NAME, PROFILE_QUEUE_NAME, TOMBSTONE_QUEUE_NAME } from '#libs/queues/queue.constants';
 import { calculateDsnpHash } from '#libs/utils/ipfs';
 import { IpfsService } from '#libs/utils/ipfs.client';
 
@@ -132,16 +126,8 @@ export class DsnpAnnouncementProcessor {
 
   private async queueUpdate(data: IRequestJob) {
     const updateDto = data.content as UpdateDto;
-    const updateAnnouncementType: AnnouncementType = await this.getAnnouncementTypeFromModifiableAnnouncementType(
-      updateDto.targetAnnouncementType,
-    );
-    const update = await this.processUpdate(
-      updateDto,
-      updateAnnouncementType,
-      updateDto.targetContentHash ?? '',
-      data.dsnpUserId,
-      data.assetToMimeType,
-    );
+    const updateAnnouncementType: AnnouncementType = await this.getAnnouncementTypeFromModifiableAnnouncementType(updateDto.targetAnnouncementType);
+    const update = await this.processUpdate(updateDto, updateAnnouncementType, updateDto.targetContentHash ?? '', data.dsnpUserId, data.assetToMimeType);
     await this.updateQueue.add(`Update Job - ${data.id}`, update, {
       jobId: data.id,
       removeOnFail: false,
@@ -160,9 +146,7 @@ export class DsnpAnnouncementProcessor {
 
   private async queueTombstone(data: IRequestJob) {
     const tombStoneDto = data.content as TombstoneDto;
-    const announcementType: AnnouncementType = await this.getAnnouncementTypeFromModifiableAnnouncementType(
-      tombStoneDto.targetAnnouncementType,
-    );
+    const announcementType: AnnouncementType = await this.getAnnouncementTypeFromModifiableAnnouncementType(tombStoneDto.targetAnnouncementType);
     const tombstone = createTombstone(data.dsnpUserId, announcementType, tombStoneDto.targetContentHash ?? '');
     await this.tombstoneQueue.add(`Tombstone Job - ${data.id}`, tombstone, {
       jobId: data.id,
@@ -171,9 +155,7 @@ export class DsnpAnnouncementProcessor {
     });
   }
 
-  private async getAnnouncementTypeFromModifiableAnnouncementType(
-    modifiableAnnouncementType: ModifiableAnnouncementTypeDto,
-  ): Promise<AnnouncementType> {
+  private async getAnnouncementTypeFromModifiableAnnouncementType(modifiableAnnouncementType: ModifiableAnnouncementTypeDto): Promise<AnnouncementType> {
     this.logger.debug(`Getting announcement type from modifiable announcement type`);
     switch (modifiableAnnouncementType) {
       case ModifiableAnnouncementTypeDto.BROADCAST:
@@ -185,13 +167,10 @@ export class DsnpAnnouncementProcessor {
     }
   }
 
-  public async prepareNote(noteContent: any, assetToMimeType?: Map<string, string>): Promise<[string, string, string]> {
-    this.logger.debug(`Preparing note`);
+  public async prepareNote(noteContent: BroadcastDto | ReplyDto | UpdateDto, assetToMimeType?: IRequestJob['assetToMimeType']): Promise<[string, string, string]> {
+    this.logger.debug(`Preparing note of type: ${typeof noteContent.content}`);
     const tags: ActivityContentTag[] = this.prepareTags(noteContent?.content.tag);
-    const attachments: ActivityContentAttachment[] = await this.prepareAttachments(
-      noteContent.content.assets,
-      assetToMimeType,
-    );
+    const attachments: ActivityContentAttachment[] = await this.prepareAttachments(noteContent.content.assets, assetToMimeType);
 
     const note = createNote(noteContent.content.content ?? '', new Date(noteContent.content.published ?? ''), {
       name: noteContent.content.name,
@@ -205,16 +184,22 @@ export class DsnpAnnouncementProcessor {
     return [cid, ipfsUrl, hash];
   }
 
-  private prepareTags(tagData?: any[]): ActivityContentTag[] {
+  private prepareTags(tagData?: TagDto[]): ActivityContentTag[] {
     this.logger.debug(`Preparing tags`);
     const tags: ActivityContentTag[] = [];
     if (tagData) {
       tagData.forEach((tag) => {
         switch (tag.type) {
           case TagTypeDto.Hashtag:
+            if (!tag.name) {
+              throw new Error(`Tag name is required`);
+            }
             tags.push({ name: tag.name });
             break;
           case TagTypeDto.Mention:
+            if (!tag.mentionedId) {
+              throw new Error(`Mentioned ID is required`);
+            }
             tags.push({
               name: tag.name,
               type: 'Mention',
@@ -229,33 +214,38 @@ export class DsnpAnnouncementProcessor {
     return tags;
   }
 
-  private async prepareAttachments(
-    assetData?: any[],
-    assetToMimeType?: Map<string, string>,
-  ): Promise<ActivityContentAttachment[]> {
+  private async prepareAttachments(assetData?: AssetDto[], assetToMimeType?: IRequestJob['assetToMimeType']): Promise<ActivityContentAttachment[]> {
     const attachments: ActivityContentAttachment[] = [];
     if (assetData) {
       const promises = assetData.map(async (asset) => {
-        switch (asset.type) {
-          case AttachmentTypeDto.LINK:
-            attachments.push(this.prepareLinkAttachment(asset));
-            break;
-          case AttachmentTypeDto.IMAGE:
-            attachments.push(await this.prepareImageAttachment(asset, assetToMimeType));
-            break;
-          case AttachmentTypeDto.VIDEO:
-            attachments.push(await this.prepareVideoAttachment(asset, assetToMimeType));
-            break;
-          case AttachmentTypeDto.AUDIO:
-            attachments.push(await this.prepareAudioAttachment(asset, assetToMimeType));
-            break;
-          default:
-            throw new Error(`Unsupported attachment type ${typeof asset.type}`);
+        if (asset.references) {
+          const assetPromises = asset.references.map(async (reference) => {
+            if (!assetToMimeType) {
+              throw new Error(`asset ${reference.referenceId} should have a mimeTypes`);
+            }
+            const { attachmentType } = assetToMimeType[reference.referenceId];
+            switch (attachmentType) {
+              case AttachmentType.LINK:
+                attachments.push(this.prepareLinkAttachment(asset));
+                break;
+              case AttachmentType.IMAGE:
+                attachments.push(await this.prepareImageAttachment(asset, assetToMimeType));
+                break;
+              case AttachmentType.VIDEO:
+                attachments.push(await this.prepareVideoAttachment(asset, assetToMimeType));
+                break;
+              case AttachmentType.AUDIO:
+                attachments.push(await this.prepareAudioAttachment(asset, assetToMimeType));
+                break;
+              default:
+                throw new Error(`Unsupported attachment type ${attachmentType}`);
+            }
+          });
+          await Promise.all(assetPromises);
         }
       });
       await Promise.all(promises);
     }
-
     return attachments;
   }
 
@@ -268,10 +258,7 @@ export class DsnpAnnouncementProcessor {
     };
   }
 
-  private async prepareImageAttachment(
-    asset: AssetDto,
-    assetToMimeType?: Map<string, string>,
-  ): Promise<ActivityContentImage> {
+  private async prepareImageAttachment(asset: AssetDto, assetToMimeType?: IRequestJob['assetToMimeType']): Promise<ActivityContentImage> {
     const imageLinks: ActivityContentImageLink[] = [];
     if (asset.references) {
       const promises = asset.references.map(async (reference) => {
@@ -301,10 +288,7 @@ export class DsnpAnnouncementProcessor {
     };
   }
 
-  private async prepareVideoAttachment(
-    asset: AssetDto,
-    assetToMimeType?: Map<string, string>,
-  ): Promise<ActivityContentVideo> {
+  private async prepareVideoAttachment(asset: AssetDto, assetToMimeType?: IRequestJob['assetToMimeType']): Promise<ActivityContentVideo> {
     const videoLinks: ActivityContentVideoLink[] = [];
     let duration: string | undefined = '';
 
@@ -338,10 +322,7 @@ export class DsnpAnnouncementProcessor {
     };
   }
 
-  private async prepareAudioAttachment(
-    asset: AssetDto,
-    assetToMimeType?: Map<string, string>,
-  ): Promise<ActivityContentAudio> {
+  private async prepareAudioAttachment(asset: AssetDto, assetToMimeType?: IRequestJob['assetToMimeType']): Promise<ActivityContentAudio> {
     const audioLinks: ActivityContentAudioLink[] = [];
     let duration = '';
     if (asset.references) {
@@ -373,21 +354,13 @@ export class DsnpAnnouncementProcessor {
     };
   }
 
-  private async processBroadcast(
-    content: BroadcastDto,
-    dsnpUserId: string,
-    assetToMimeType?: Map<string, string>,
-  ): Promise<BroadcastAnnouncement> {
+  private async processBroadcast(content: BroadcastDto, dsnpUserId: string, assetToMimeType?: IRequestJob['assetToMimeType']): Promise<BroadcastAnnouncement> {
     this.logger.debug(`Processing broadcast`);
     const [cid, ipfsUrl, hash] = await this.prepareNote(content, assetToMimeType);
     return createBroadcast(dsnpUserId, ipfsUrl, hash);
   }
 
-  private async processReply(
-    content: ReplyDto,
-    dsnpUserId: string,
-    assetToMimeType?: Map<string, string>,
-  ): Promise<ReplyAnnouncement> {
+  private async processReply(content: ReplyDto, dsnpUserId: string, assetToMimeType?: IRequestJob['assetToMimeType']): Promise<ReplyAnnouncement> {
     this.logger.debug(`Processing reply for ${content.inReplyTo}`);
     const [cid, ipfsUrl, hash] = await this.prepareNote(content, assetToMimeType);
     return createReply(dsnpUserId, ipfsUrl, hash, content.inReplyTo);
@@ -403,23 +376,16 @@ export class DsnpAnnouncementProcessor {
     targetAnnouncementType: AnnouncementType,
     targetContentHash: string,
     dsnpUserId: string,
-    assetToMimeType?: Map<string, string>,
+    assetToMimeType?: IRequestJob['assetToMimeType'],
   ): Promise<UpdateAnnouncement> {
     this.logger.debug(`Processing update`);
     const [cid, ipfsUrl, hash] = await this.prepareNote(content, assetToMimeType);
     return createUpdate(dsnpUserId, ipfsUrl, hash, targetAnnouncementType, targetContentHash);
   }
 
-  private async processProfile(
-    content: ProfileDto,
-    dsnpUserId: string,
-    assetToMimeType?: Map<string, string>,
-  ): Promise<ProfileAnnouncement> {
+  private async processProfile(content: ProfileDto, dsnpUserId: string, assetToMimeType?: IRequestJob['assetToMimeType']): Promise<ProfileAnnouncement> {
     this.logger.debug(`Processing profile`);
-    const attachments: ActivityContentImageLink[] = await this.prepareProfileIconAttachments(
-      content.profile.icon ?? [],
-      assetToMimeType,
-    );
+    const attachments: ActivityContentImageLink[] = await this.prepareProfileIconAttachments(content.profile.icon ?? [], assetToMimeType);
 
     const profileActivity: ActivityContentProfile = {
       '@context': 'https://www.w3.org/ns/activitystreams',
@@ -436,10 +402,7 @@ export class DsnpAnnouncementProcessor {
     return createProfile(dsnpUserId, this.formIpfsUrl(cid), hash);
   }
 
-  private async prepareProfileIconAttachments(
-    icons: any[],
-    assetToMimeType?: Map<string, string>,
-  ): Promise<ActivityContentImageLink[]> {
+  private async prepareProfileIconAttachments(icons: any[], assetToMimeType?: IRequestJob['assetToMimeType']): Promise<ActivityContentImageLink[]> {
     const attachments: ActivityContentImageLink[] = [];
 
     const promises = icons.map(async (icon) => {

--- a/services/content-publishing/libs/common/src/dtos/activity.dto.ts
+++ b/services/content-publishing/libs/common/src/dtos/activity.dto.ts
@@ -43,7 +43,7 @@ export enum TagTypeDto {
 }
 
 // eslint-disable-next-line no-shadow
-export enum AttachmentTypeDto {
+export enum AttachmentType {
   LINK = 'link',
   IMAGE = 'image',
   AUDIO = 'audio',
@@ -121,10 +121,7 @@ export class TagDto {
 }
 
 export class AssetDto {
-  @IsEnum(AttachmentTypeDto)
-  type: AttachmentTypeDto;
-
-  @ValidateIf((o) => o.type !== AttachmentTypeDto.LINK)
+  @ValidateIf((o) => o.type !== AttachmentType.LINK)
   @ValidateNested({ each: true })
   @IsArray()
   @ArrayNotEmpty()
@@ -137,7 +134,7 @@ export class AssetDto {
   @MinLength(1)
   name?: string;
 
-  @ValidateIf((o) => o.type === AttachmentTypeDto.LINK)
+  @ValidateIf((o) => o.type === AttachmentType.LINK)
   @IsString()
   @MinLength(1)
   @IsUrl({ protocols: ['http', 'https'] })

--- a/services/content-publishing/libs/common/src/interfaces/asset-job.interface.ts
+++ b/services/content-publishing/libs/common/src/interfaces/asset-job.interface.ts
@@ -1,3 +1,5 @@
+import { AttachmentType } from '#libs/dtos';
+
 export interface IAssetJob {
   ipfsCid: string;
   mimeType: string;
@@ -9,4 +11,5 @@ export interface IAssetMetadata {
   ipfsCid: string;
   mimeType: string;
   createdOn: number;
+  type: AttachmentType;
 }

--- a/services/content-publishing/libs/common/src/interfaces/request-job.interface.ts
+++ b/services/content-publishing/libs/common/src/interfaces/request-job.interface.ts
@@ -1,10 +1,13 @@
-import { AnnouncementTypeDto, RequestTypeDto } from '#libs/dtos';
-
+import { AnnouncementTypeDto, AttachmentType, RequestTypeDto } from '#libs/dtos';
+export interface IAssetTypeInfo {
+  mimeType: string;
+  attachmentType: AttachmentType;
+}
 export interface IRequestJob {
   id: string;
   announcementType: AnnouncementTypeDto;
   dsnpUserId: string;
-  assetToMimeType?: Map<string, string>;
+  assetToMimeType?: Map<string, IAssetTypeInfo>;
   content?: RequestTypeDto;
   dependencyAttempt: number;
 }

--- a/services/content-publishing/swagger.json
+++ b/services/content-publishing/swagger.json
@@ -403,15 +403,6 @@
       "AssetDto": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "link",
-              "image",
-              "audio",
-              "video"
-            ]
-          },
           "references": {
             "type": "array",
             "items": {
@@ -426,10 +417,7 @@
             "type": "string",
             "minLength": 1
           }
-        },
-        "required": [
-          "type"
-        ]
+        }
       },
       "TagDto": {
         "type": "object",


### PR DESCRIPTION
# Description
As a user, I should not have to keep track of the association between an uploaded asset reference ID and its media type. More specifically, I should not be able to tell content-publisher the type of an asset in an Announcment publish request (Broadcast, Reply, etc), as that opens up an attack vector to specify a media type that does not match the actual uploaded asset. content-publisher should be its own source of truth in coordinating asset type with the actual asset.

- [x] Remove `type` from `BroadcastDto`, `UpdateDto`, `ReplyDto`
   -  Removed from `AssetDto`, which is included by all of the above
- [x] Update OpenAPI spec
   -  Updated using the `generate` scripts 
- [x] Add `type` to cached metadata for uploaded asset

Closes #338 