### PR TITLE
fix: regex for release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           valid=false
           test_run=false
-          ENTIRE_TAG_RE="^(([[:alpha:]]+)-)?(.*)$"
+          ENTIRE_TAG_RE="^(([[:alpha:]\-]+)-)?(.*)$"
           VERSION_TAG_RE="^v[\.]?([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alpha:][:digit:]\.]+)*)$"
           TAG="${{ github.event.release.tag_name }}"
           echo "Running with tag: ${TAG}"


### PR DESCRIPTION
Fixes the regex used to validate the release tag for the CI pipeline. Was having trouble with a service name containing an embedded hyphen, like `content-publishing` or `content-watcher`.