### PR TITLE
bug: Make sure blockCount is not longer than the current chain length

### DIFF
--- a/services/content-watcher/libs/common/src/crawler/crawler.service.ts
+++ b/services/content-watcher/libs/common/src/crawler/crawler.service.ts
@@ -37,6 +37,10 @@ export class CrawlerService extends BaseConsumer {
         job.data.startBlock = startBlock;
         this.logger.debug(`No starting block specified; starting from end of chain at block ${startBlock}`);
       }
+      // Make sure blockCount is not longer than the current chain length
+      if (job.data.blockCount >= startBlock) {
+        job.data.blockCount = startBlock;
+      }
       let blockList = new Array(job.data.blockCount).fill(0).map((_v, index) => startBlock - index);
       blockList.reverse();
 


### PR DESCRIPTION
# Problem

When running a local development frequency node, the chain length will be quite short. This results in trying to scan a blocklist that includes negative numbers, which causes the scan to fail and no previous content to be found.

# Solution
```javascript
      // Make sure blockCount is not longer than the current chain length
      if (job.data.blockCount >= startBlock) {
        job.data.blockCount = startBlock;
      }
```
## Steps to Verify:

1. Run SAT with a local frequency node and verify that the initial scan completes correctly.
