### PR TITLE
graph service should replace PROVIDER_BASE_URL with WEBHOOK_BASE_URL

### DIFF
--- a/services/graph/ENVIRONMENT.md
+++ b/services/graph/ENVIRONMENT.md
@@ -26,6 +26,6 @@ This application recognizes the following environment variables:
 | ---------------------------------------- | -------------------------------------------------------------------------------------- | :--------: | :-------: | :-----: |
 | `PROVIDER_ACCESS_TOKEN`                  | An optional bearer token authentication to the provider webhook                        |   string   |           |         |
 | `CONNECTIONS_PER_PROVIDER_RESPONSE_PAGE` | Number of connection/page to request when requesting provider connections from webhook |
-| `PROVIDER_BASE_URL`                      | Base URL for provider webhook endpoints                                                |    URL     |     Y     |         |
+| `WEBHOOK_BASE_URL`                       | Base URL for provider webhook endpoints                                                |    URL     |     Y     |         |
 | `WEBHOOK_FAILURE_THRESHOLD`              | Number of failures allowing in the provider webhook before the service is marked down  |    > 0     |           |    3    |
 | `WEBHOOK_RETRY_INTERVAL_SECONDS`         | Number of seconds between provider webhook retry attempts when failing                 |    > 0     |           |   10    |

--- a/services/graph/apps/api/src/build-openapi.ts
+++ b/services/graph/apps/api/src/build-openapi.ts
@@ -14,7 +14,7 @@ process.env.FREQUENCY_HTTP_URL = 'http://127.0.0.1';
 process.env.PROVIDER_ACCOUNT_SEED_PHRASE =
   'offer debate skin describe light badge fish turtle actual inject struggle border';
 process.env.PROVIDER_ID = '0';
-process.env.PROVIDER_BASE_URL = 'http://127.0.0.1';
+process.env.WEBHOOK_BASE_URL = 'http://127.0.0.1';
 process.env.CAPACITY_LIMIT = '{"serviceLimit":{"type":"percentage","value":"80"}}';
 
 // eslint-disable-next-line

--- a/services/graph/env.template
+++ b/services/graph/env.template
@@ -39,7 +39,7 @@ RECONNECTION_SERVICE_REQUIRED=true
 ### The following are only applicable if RECONNECTION_SERVICE_REQUIRED is 'true'
 
 # Base URL for provider webhook endpoints
-PROVIDER_BASE_URL=https://some-provider/api/v1.0.0
+WEBHOOK_BASE_URL=https://some-provider/api/v1.0.0
 
 # An optional bearer token authentication to the provider webhook
 PROVIDER_ACCESS_TOKEN=some-token

--- a/services/graph/libs/common/src/blockchain/blockchain.service.spec.ts
+++ b/services/graph/libs/common/src/blockchain/blockchain.service.spec.ts
@@ -8,7 +8,7 @@ describe('BlockchainService', () => {
     const configService = {
       logger: jest.fn(),
       nestConfigService: jest.fn(),
-      providerBaseUrl: jest.fn(),
+      webhookBaseUrl: jest.fn(),
       providerApiToken: jest.fn(),
       getProviderId: jest.fn(),
       getQueueHighWater: jest.fn(),

--- a/services/graph/libs/common/src/config/config.service.spec.ts
+++ b/services/graph/libs/common/src/config/config.service.spec.ts
@@ -45,7 +45,7 @@ describe('GraphSericeConfig', () => {
     GRAPH_ENVIRONMENT_TYPE: undefined,
     PROVIDER_ACCOUNT_SEED_PHRASE: undefined,
     PROVIDER_ID: undefined,
-    PROVIDER_BASE_URL: undefined,
+    WEBHOOK_BASE_URL: undefined,
     PROVIDER_ACCESS_TOKEN: undefined,
     WEBHOOK_FAILURE_THRESHOLD: undefined,
     HEALTH_CHECK_SUCCESS_THRESHOLD: undefined,
@@ -150,7 +150,7 @@ describe('GraphSericeConfig', () => {
     });
 
     it('should get provider base url', () => {
-      expect(graphServiceConfig.providerBaseUrl?.toString()).toStrictEqual(ALL_ENV.PROVIDER_BASE_URL?.toString());
+      expect(graphServiceConfig.webhookBaseUrl?.toString()).toStrictEqual(ALL_ENV.WEBHOOK_BASE_URL?.toString());
     });
 
     it('should get provider api token', () => {

--- a/services/graph/libs/common/src/config/config.service.ts
+++ b/services/graph/libs/common/src/config/config.service.ts
@@ -15,7 +15,7 @@ export interface ConfigEnvironmentVariables {
   PROVIDER_ID: string;
   RECONNECTION_SERVICE_REQUIRED: boolean;
   BLOCKCHAIN_SCAN_INTERVAL_SECONDS: number;
-  PROVIDER_BASE_URL: string;
+  WEBHOOK_BASE_URL: string;
   PROVIDER_ACCESS_TOKEN: string;
   WEBHOOK_FAILURE_THRESHOLD: number;
   HEALTH_CHECK_SUCCESS_THRESHOLD: number;
@@ -62,8 +62,8 @@ export class ConfigService {
     return this.nestConfigService.get('CACHE_KEY_PREFIX')!;
   }
 
-  public get providerBaseUrl(): URL {
-    return this.nestConfigService.get<URL>('PROVIDER_BASE_URL')!;
+  public get webhookBaseUrl(): URL {
+    return this.nestConfigService.get<URL>('WEBHOOK_BASE_URL')!;
   }
 
   public get providerApiToken(): string | undefined {

--- a/services/graph/libs/common/src/config/env.config.ts
+++ b/services/graph/libs/common/src/config/env.config.ts
@@ -51,7 +51,7 @@ export const configModuleOptions: ConfigModuleOptions = {
       }
       return value;
     }),
-    PROVIDER_BASE_URL: Joi.string().uri().when('RECONNECTION_SERVICE_REQUIRED', {
+    WEBHOOK_BASE_URL: Joi.string().uri().when('RECONNECTION_SERVICE_REQUIRED', {
       is: true,
       then: Joi.string().required(),
     }),

--- a/services/graph/libs/common/src/services/provider-webhook.service.ts
+++ b/services/graph/libs/common/src/services/provider-webhook.service.ts
@@ -34,7 +34,7 @@ export class ProviderWebhookService implements OnModuleDestroy {
   ) {
     this.logger = new Logger(this.constructor.name);
     this.webhook = axios.create({
-      baseURL: this.configService.providerBaseUrl.toString(),
+      baseURL: this.configService.webhookBaseUrl.toString(),
     });
 
     this.webhook.defaults.headers.common.Authorization = this.configService.providerApiToken;
@@ -60,7 +60,7 @@ export class ProviderWebhookService implements OnModuleDestroy {
 
     if (this.failedHealthChecks > 0) {
       if (this.failedHealthChecks >= this.configService.healthCheckMaxRetries) {
-        this.logger.error(`FATAL ERROR: Failed to connect to provider webhook at '${this.configService.providerBaseUrl}' after ${this.failedHealthChecks} attempts.`);
+        this.logger.error(`FATAL ERROR: Failed to connect to provider webhook at '${this.configService.webhookBaseUrl}' after ${this.failedHealthChecks} attempts.`);
         this.eventEmitter.emit('shutdown');
         return;
       }

--- a/services/graph/package-lock.json
+++ b/services/graph/package-lock.json
@@ -49,7 +49,7 @@
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@nestjs/testing": "^10.3.10",
-        "@projectlibertylabs/frequency-scenario-template": "^1.1.5",
+        "@projectlibertylabs/frequency-scenario-template": "^1.1.6",
         "@projectlibertylabs/ts-config": "file:../../packages/ts-config",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
@@ -4220,10 +4220,11 @@
       }
     },
     "node_modules/@projectlibertylabs/frequency-scenario-template": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@projectlibertylabs/frequency-scenario-template/-/frequency-scenario-template-1.1.5.tgz",
-      "integrity": "sha512-gH5OQoDzeu+QF5geTziD1aeFtVSAE99yvQZfnneDB1IpHPlbEpSMgiy2IfxsqbsxQU7Rw3cCpGj1chFx7j0ujg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@projectlibertylabs/frequency-scenario-template/-/frequency-scenario-template-1.1.6.tgz",
+      "integrity": "sha512-x7kWPG09WIJhxnzDqV6IXPKduPBMdfkFWBX5rH4skzutk+VUfpFpms7qsuyuvINbipg5JeGoJ8oq6TCJWkFZ8g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/frequency-schemas": "^1.1.0",
         "@dsnp/graph-sdk": "^1.1.3",

--- a/services/graph/package.json
+++ b/services/graph/package.json
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@nestjs/testing": "^10.3.10",
-    "@projectlibertylabs/frequency-scenario-template": "^1.1.5",
+    "@projectlibertylabs/frequency-scenario-template": "^1.1.6",
     "@projectlibertylabs/ts-config": "file:../../packages/ts-config",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
## Description
The gateway microservices that use webhooks previously used the environment variable `PROVIDER_BASE_URL` as the webhook target server. The `social-app-template` has adopted a new nomenclature using `WEBHOOK_BASE_URL`. All micro services should be in sync with the `social-app-template` and use the new nomenclature.

## Acceptance Criteria

- [ ] All microservices that use webhooks use `WEBHOOK_BASE_URL` to provision their webhook.

  - [ ] graph service

Follow up to remove entirely: https://github.com/ProjectLibertyLabs/gateway/issues/339
