### PR TITLE
fix: content-watcher scanning end of chain

### DIFF
--- a/services/content-watcher/libs/common/src/scanner/scanner.service.ts
+++ b/services/content-watcher/libs/common/src/scanner/scanner.service.ts
@@ -13,7 +13,7 @@ import { BlockchainService } from '../blockchain/blockchain.service';
 import * as QueueConstants from '../queues/queue-constants';
 import { EVENTS_TO_WATCH_KEY, LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY, REGISTERED_WEBHOOK_KEY } from '../constants';
 import { ChainWatchOptionsDto } from '../dtos/chain.watch.dto';
-import * as RedisUtils from '../utils/redis';
+import * as RedisUtils from '#libs/utils/redis';
 import { ChainEventProcessorService } from '../blockchain/chain-event-processor.service';
 import { IScanReset } from '../interfaces/scan-reset.interface';
 
@@ -143,6 +143,7 @@ export class ScannerService implements OnApplicationBootstrap, OnApplicationShut
       nextBlock = Number((await this.cache.get(LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY)) ?? '0');
       if (!nextBlock) {
         nextBlock = await this.blockchainService.getLatestFinalizedBlockNumber();
+        this.setLastSeenBlockNumber(nextBlock);
       }
 
       nextBlock += 1;

--- a/services/content-watcher/package.json
+++ b/services/content-watcher/package.json
@@ -126,7 +126,19 @@
       "<rootDir>/libs/"
     ],
     "moduleNameMapper": {
-      "^@content-watcher-common(|/.*)$": "<rootDir>/libs/common/src/$1"
+      "^@content-watcher-common(|/.*)$": "<rootDir>/libs/common/src/$1",
+      "^@libs/common(|/.*)$": "<rootDir>/libs/common/src/$1",
+      "^#libs/blockchain(|/.*)$": "<rootDir>/libs/common/src/blockchain/$1",
+      "^#libs/config(|/.*)$": "<rootDir>/libs/common/src/config/$1",
+      "^#libs/crawler(|/.*)$": "<rootDir>/libs/common/src/crawler/$1",
+      "^#libs/dtos(|/.*)$": "<rootDir>/libs/common/src/dtos/$1",
+      "^#libs/interfaces(|/.*)$": "<rootDir>/libs/common/src/interfaces/$1",
+      "^#libs/ipfs(|/.*)$": "<rootDir>/libs/common/src/ipfs/$1",
+      "^#libs/pubsub(|/.*)$": "<rootDir>/libs/common/src/pubsub/$1",
+      "^#libs/queues(|/.*)$": "<rootDir>/libs/common/src/queues/$1",
+      "^#libs/scanner(|/.*)$": "<rootDir>/libs/common/src/scanner/$1",
+      "^#libs/types(|/.*)$": "<rootDir>/libs/common/src/types/$1",
+      "^#libs/utils(|/.*)$": "<rootDir>/libs/common/src/utils/$1"
     }
   }
 }

--- a/services/content-watcher/tsconfig.json
+++ b/services/content-watcher/tsconfig.json
@@ -15,6 +15,72 @@
       ],
       "@libs/common/*": [
         "libs/common/src/*"
+      ],
+      "#libs/blockchain": [
+        "libs/common/src/blockchain"
+      ],
+      "#libs/blockchain/*": [
+        "libs/common/src/blockchain/*"
+      ],
+      "#libs/config": [
+        "libs/common/src/config"
+      ],
+      "#libs/config/*": [
+        "libs/common/src/config/*"
+      ],
+      "#libs/crawler": [
+        "libs/common/src/crawler"
+      ],
+      "#libs/crawler/*": [
+        "libs/common/src/crawler/*"
+      ],
+      "#libs/dtos": [
+        "libs/common/src/dtos"
+      ],
+      "#libs/dtos/*": [
+        "libs/common/src/dtos/*"
+      ],
+      "#libs/interfaces": [
+        "libs/common/src/interfaces"
+      ],
+      "#libs/interfaces/*": [
+        "libs/common/src/interfaces/*"
+      ],
+      "#libs/ipfs": [
+        "libs/common/src/ipfs"
+      ],
+      "#libs/ipfs/*": [
+        "libs/common/src/ipfs/*"
+      ],
+      "#libs/pubsub": [
+        "libs/common/src/pubsub"
+      ],
+      "#libs/pubsub/*": [
+        "libs/common/src/pubsub/*"
+      ],
+      "#libs/queues": [
+        "libs/common/src/queues"
+      ],
+      "#libs/queues/*": [
+        "libs/common/src/queues/*"
+      ],
+      "#libs/scanner": [
+        "libs/common/src/scanner"
+      ],
+      "#libs/scanner/*": [
+        "libs/common/src/scanner/*"
+      ],
+      "#libs/types": [
+        "libs/common/src/types"
+      ],
+      "#libs/types/*": [
+        "libs/common/src/types/*"
+      ],
+      "#libs/utils": [
+        "libs/common/src/utils"
+      ],
+      "#libs/utils/*": [
+        "libs/common/src/utils/*"
       ]
     },
     "typeRoots": [


### PR DESCRIPTION
This PR fixes the issue where content-watcher does not find new content at the end of the chain as it's posted.

Closes #351 