### PR TITLE
fix: resume queue in content-publishing when Capacity is available

### DIFF
--- a/services/content-publishing/apps/worker/src/publisher/publishing.service.ts
+++ b/services/content-publishing/apps/worker/src/publisher/publishing.service.ts
@@ -112,6 +112,7 @@ export class PublishingService extends BaseConsumer implements OnApplicationBoot
     if (await this.publishQueue.isPaused()) {
       this.logger.debug('Received capacity.available event');
     }
+    await this.publishQueue.resume();
     try {
       this.schedulerRegistry.deleteTimeout(CAPACITY_EPOCH_TIMEOUT_NAME);
     } catch (err) {


### PR DESCRIPTION
# Description
Resume queue when Capacity is available (was logging event, but not resuming queue)

# Acceptance Criteria
- [x] Publishing queue is resumed when Capacity becomes available

Closes #392 