### PR TITLE
feat: at startup, check to make sure provider seed phrase matches configured provider ID

### DIFF
--- a/services/account/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/account/libs/common/src/blockchain/blockchain.service.ts
@@ -86,6 +86,7 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
       }
       this.api = await ApiPromise.create({ provider, ...options }).then((api) => api.isReady);
       this.readyResolve(await this.api.isReady);
+      await this.validateProviderSeedPhrase();
       this.logger.log('Blockchain API ready.');
     } catch (err) {
       this.readyReject(err);
@@ -419,5 +420,14 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     }
 
     return publicKeyValues as PublicKeyValues;
+  }
+
+  public async validateProviderSeedPhrase() {
+    const { providerPublicKeyAddress, providerId } = this.configService;
+    const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
+
+    if (providerPublicKeyAddress && resolvedProviderId !== providerId) {
+      throw new Error('Provided account secret does not match configured Provider ID');
+    }
   }
 }

--- a/services/account/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/account/libs/common/src/blockchain/blockchain.service.ts
@@ -424,10 +424,12 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
 
   public async validateProviderSeedPhrase() {
     const { providerPublicKeyAddress, providerId } = this.configService;
-    const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
+    if (providerPublicKeyAddress) {
+      const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
 
-    if (providerPublicKeyAddress && resolvedProviderId !== providerId) {
-      throw new Error('Provided account secret does not match configured Provider ID');
+      if (resolvedProviderId !== providerId) {
+        throw new Error('Provided account secret does not match configured Provider ID');
+      }
     }
   }
 }

--- a/services/content-publishing/libs/common/src/blockchain/blockchain.service.spec.ts
+++ b/services/content-publishing/libs/common/src/blockchain/blockchain.service.spec.ts
@@ -1,18 +1,87 @@
-import { describe, it, beforeEach } from '@jest/globals';
+import { describe, it } from '@jest/globals';
 import { BlockchainService } from './blockchain.service';
+import { ConfigService } from '#libs/config';
+import { ApiPromise } from '@polkadot/api';
+import { Test } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
 
 describe('BlockchainService', () => {
+  let mockApi: any;
   let blockchainService: BlockchainService;
+  let configService: ConfigService;
 
-  beforeEach(async () => {});
+  beforeAll(async () => {
+    mockApi = {
+      createType: jest.fn(),
+      query: {
+        capacity: {
+          currentEpochInfo: jest.fn(),
+        },
+      },
+    } as unknown as ApiPromise;
 
-  describe('createExtrinsicCall', () => {
-    it('should return an extrinsic call', async () => {
-      const pallet = 'messages';
-      const extrinsic = 'addIpfsMessage';
-      const schemaId = 1;
-      const cid = 'QmRgJZmR6Z6yB5k9aLXjzJ6jG8L6tq4v4J9zQfDz7p3J9v';
-      const payloadLength = 100;
+    process.env = {
+      REDIS_URL: undefined,
+      FREQUENCY_URL: undefined,
+      FREQUENCY_HTTP_URL: undefined,
+      API_PORT: undefined,
+      BLOCKCHAIN_SCAN_INTERVAL_SECONDS: undefined,
+      TRUST_UNFINALIZED_BLOCKS: undefined,
+      PROVIDER_ACCOUNT_SEED_PHRASE: '//Alice',
+      PROVIDER_ID: '1',
+      SIWF_URL: undefined,
+      SIWF_DOMAIN: undefined,
+      WEBHOOK_BASE_URL: undefined,
+      PROVIDER_ACCESS_TOKEN: undefined,
+      WEBHOOK_FAILURE_THRESHOLD: undefined,
+      HEALTH_CHECK_SUCCESS_THRESHOLD: undefined,
+      WEBHOOK_RETRY_INTERVAL_SECONDS: undefined,
+      HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: undefined,
+      HEALTH_CHECK_MAX_RETRIES: undefined,
+      CAPACITY_LIMIT: undefined,
+      CACHE_KEY_PREFIX: undefined,
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          ignoreEnvFile: true,
+          load: [() => process.env],
+        }),
+      ],
+      controllers: [],
+      providers: [ConfigService, BlockchainService],
+    }).compile();
+
+    await ConfigModule.envVariablesLoaded;
+
+    configService = moduleRef.get<ConfigService>(ConfigService);
+    blockchainService = moduleRef.get<BlockchainService>(BlockchainService);
+    blockchainService.api = mockApi;
+  });
+
+  describe('validateProviderSeedPhrase', () => {
+    beforeAll(() => {
+      jest.spyOn(configService, 'providerPublicKeyAddress', 'get').mockReturnValue('<public address>');
+      jest.spyOn(blockchainService, 'publicKeyToMsaId').mockResolvedValue('1');
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should not throw if seed phrase is correct for provider', async () => {
+      await expect(blockchainService.validateProviderSeedPhrase()).resolves.not.toThrow();
+    });
+
+    it('should not throw if no seed phrase configured (read-only mode)', async () => {
+      jest.spyOn(configService, 'providerPublicKeyAddress', 'get').mockReturnValueOnce('');
+      await expect(blockchainService.validateProviderSeedPhrase()).resolves.not.toThrow();
+    });
+
+    it('should throw if seed phrase is incorrect for provider', async () => {
+      jest.spyOn(blockchainService, 'publicKeyToMsaId').mockResolvedValueOnce(null);
+      await expect(blockchainService.validateProviderSeedPhrase()).rejects.toThrow();
     });
   });
 });

--- a/services/content-publishing/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/content-publishing/libs/common/src/blockchain/blockchain.service.ts
@@ -197,10 +197,12 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
 
   public async validateProviderSeedPhrase() {
     const { providerPublicKeyAddress, providerId } = this.configService;
-    const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
+    if (providerPublicKeyAddress) {
+      const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
 
-    if (providerPublicKeyAddress && resolvedProviderId !== providerId) {
-      throw new Error('Provided account secret does not match configured Provider ID');
+      if (resolvedProviderId !== providerId) {
+        throw new Error('Provided account secret does not match configured Provider ID');
+      }
     }
   }
 }

--- a/services/content-publishing/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/content-publishing/libs/common/src/blockchain/blockchain.service.ts
@@ -49,6 +49,7 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     }
     this.api = await ApiPromise.create({ provider, ...options });
     this.readyResolve(await this.api.isReady);
+    await this.validateProviderSeedPhrase();
     this.logger.log('Blockchain API ready.');
   }
 
@@ -186,5 +187,20 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
     }
 
     return schemaId;
+  }
+
+  public async publicKeyToMsaId(publicKey: string): Promise<string | null> {
+    const handleResponse = await this.query('msa', 'publicKeyToMsaId', publicKey);
+    if (handleResponse.isSome) return handleResponse.unwrap().toString();
+    return null;
+  }
+
+  public async validateProviderSeedPhrase() {
+    const { providerPublicKeyAddress, providerId } = this.configService;
+    const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
+
+    if (providerPublicKeyAddress && resolvedProviderId !== providerId) {
+      throw new Error('Provided account secret does not match configured Provider ID');
+    }
   }
 }

--- a/services/graph/libs/common/src/blockchain/blockchain.service.spec.ts
+++ b/services/graph/libs/common/src/blockchain/blockchain.service.spec.ts
@@ -1,36 +1,62 @@
 import { BlockchainService } from './blockchain.service';
 import { ConfigService } from '../config/config.service';
+import { ApiPromise } from '@polkadot/api';
+import { Test } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
 
 describe('BlockchainService', () => {
+  let mockApi: any;
   let blockchainService: BlockchainService;
+  let configService: ConfigService;
 
   beforeAll(async () => {
-    const configService = {
-      logger: jest.fn(),
-      nestConfigService: jest.fn(),
-      providerBaseUrl: jest.fn(),
-      providerApiToken: jest.fn(),
-      getProviderId: jest.fn(),
-      getQueueHighWater: jest.fn(),
-      getApiPort: jest.fn(),
-      getReconnectionServiceRequired: jest.fn(),
-      getBlockchainScanIntervalMinutes: jest.fn(),
-      getRedisUrl: jest.fn(),
-      getFrequencyUrl: jest.fn(),
-      getGraphEnvironmentType: jest.fn(),
-      getProviderAccountSeedPhrase: jest.fn(),
-      redisUrl: jest.fn(),
-      frequencyUrl: jest.fn(),
-      getHealthCheckMaxRetries: jest.fn(),
-      getHealthCheckMaxRetryIntervalSeconds: jest.fn(),
-      getHealthCheckSuccessThreshold: jest.fn(),
-      getWebhookFailureThreshold: jest.fn(),
-      getWebhookRetryIntervalSeconds: jest.fn(),
-      webhookRetryIntervalSeconds: jest.fn(),
-      getPageSize: jest.fn(),
-      getDebounceSeconds: jest.fn(),
+    mockApi = {
+      createType: jest.fn(),
+      query: {
+        capacity: {
+          currentEpochInfo: jest.fn(),
+        },
+      },
+    } as unknown as ApiPromise;
+
+    process.env = {
+      REDIS_URL: undefined,
+      FREQUENCY_URL: undefined,
+      FREQUENCY_HTTP_URL: undefined,
+      API_PORT: undefined,
+      BLOCKCHAIN_SCAN_INTERVAL_SECONDS: undefined,
+      TRUST_UNFINALIZED_BLOCKS: undefined,
+      PROVIDER_ACCOUNT_SEED_PHRASE: '//Alice',
+      PROVIDER_ID: '1',
+      SIWF_URL: undefined,
+      SIWF_DOMAIN: undefined,
+      WEBHOOK_BASE_URL: undefined,
+      PROVIDER_ACCESS_TOKEN: undefined,
+      WEBHOOK_FAILURE_THRESHOLD: undefined,
+      HEALTH_CHECK_SUCCESS_THRESHOLD: undefined,
+      WEBHOOK_RETRY_INTERVAL_SECONDS: undefined,
+      HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: undefined,
+      HEALTH_CHECK_MAX_RETRIES: undefined,
+      CAPACITY_LIMIT: undefined,
+      CACHE_KEY_PREFIX: undefined,
     };
-    blockchainService = new BlockchainService(configService as unknown as ConfigService);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          ignoreEnvFile: true,
+          load: [() => process.env],
+        }),
+      ],
+      controllers: [],
+      providers: [ConfigService, BlockchainService],
+    }).compile();
+
+    await ConfigModule.envVariablesLoaded;
+
+    configService = moduleRef.get<ConfigService>(ConfigService);
+    blockchainService = moduleRef.get<BlockchainService>(BlockchainService);
+    blockchainService.api = mockApi;
   });
 
   describe('getCurrentCapacityEpochStart', () => {
@@ -48,6 +74,31 @@ describe('BlockchainService', () => {
 
       // Assert
       expect(result).toBe(expectedEpochStart.toNumber());
+    });
+  });
+
+  describe('validateProviderSeedPhrase', () => {
+    beforeAll(() => {
+      jest.spyOn(configService, 'providerPublicKeyAddress', 'get').mockReturnValue('<public address>');
+      jest.spyOn(blockchainService, 'publicKeyToMsaId').mockResolvedValue('1');
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should not throw if seed phrase is correct for provider', async () => {
+      await expect(blockchainService.validateProviderSeedPhrase()).resolves.not.toThrow();
+    });
+
+    it('should not throw if no seed phrase configured (read-only mode)', async () => {
+      jest.spyOn(configService, 'providerPublicKeyAddress', 'get').mockReturnValueOnce('');
+      await expect(blockchainService.validateProviderSeedPhrase()).resolves.not.toThrow();
+    });
+
+    it('should throw if seed phrase is incorrect for provider', async () => {
+      jest.spyOn(blockchainService, 'publicKeyToMsaId').mockResolvedValueOnce(null);
+      await expect(blockchainService.validateProviderSeedPhrase()).rejects.toThrow();
     });
   });
 });

--- a/services/graph/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/graph/libs/common/src/blockchain/blockchain.service.ts
@@ -37,6 +37,13 @@ export class BlockchainService implements OnApplicationBootstrap, BeforeApplicat
 
   private logger: Logger;
 
+  private readyResolve: (boolean) => void;
+  private readyReject: (reason: any) => void;
+  private isReadyPromise = new Promise<boolean>((resolve, reject) => {
+    this.readyResolve = resolve;
+    this.readyReject = reject;
+  });
+
   public async onApplicationBootstrap() {
     const providerUrl = this.configService.frequencyUrl!;
     let provider: any;
@@ -49,13 +56,13 @@ export class BlockchainService implements OnApplicationBootstrap, BeforeApplicat
       throw new Error('Unrecognized chain URL type');
     }
     this.api = await ApiPromise.create({ provider, ...options });
-    await this.api.isReady;
+    this.readyResolve(await this.api.isReady);
+    await this.validateProviderSeedPhrase();
     this.logger.log('Blockchain API ready.');
   }
 
   public async isReady(): Promise<boolean> {
-    await this.api.isReady;
-    return true;
+    return (await this.isReadyPromise) && !!(await this.api.isReady);
   }
 
   public async beforeApplicationShutdown(_signal?: string | undefined) {
@@ -253,5 +260,20 @@ export class BlockchainService implements OnApplicationBootstrap, BeforeApplicat
     const result = results.find((receipt) => receipt.found);
     this.logger.debug(`Found tx receipt: ${JSON.stringify(result)}`);
     return result ?? { found: false, success: false };
+  }
+
+  public async publicKeyToMsaId(publicKey: string): Promise<string | null> {
+    const handleResponse = await this.query('msa', 'publicKeyToMsaId', publicKey);
+    if (handleResponse.isSome) return handleResponse.unwrap().toString();
+    return null;
+  }
+
+  public async validateProviderSeedPhrase() {
+    const { providerPublicKeyAddress, providerId } = this.configService;
+    const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
+
+    if (providerPublicKeyAddress && resolvedProviderId !== providerId) {
+      throw new Error('Provided account secret does not match configured Provider ID');
+    }
   }
 }

--- a/services/graph/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/graph/libs/common/src/blockchain/blockchain.service.ts
@@ -270,10 +270,12 @@ export class BlockchainService implements OnApplicationBootstrap, BeforeApplicat
 
   public async validateProviderSeedPhrase() {
     const { providerPublicKeyAddress, providerId } = this.configService;
-    const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
+    if (providerPublicKeyAddress) {
+      const resolvedProviderId = await this.publicKeyToMsaId(providerPublicKeyAddress || '');
 
-    if (providerPublicKeyAddress && resolvedProviderId !== providerId) {
-      throw new Error('Provided account secret does not match configured Provider ID');
+      if (resolvedProviderId !== providerId) {
+        throw new Error('Provided account secret does not match configured Provider ID');
+      }
     }
   }
 }


### PR DESCRIPTION
- Adds logic to startup in `account`, `content-publishing`, `content-watcher` to query the chain for the MSA ID associated with the public key derived from the configured seed phrase; throw an error if it does not match the configured Provider ID
- Syncs initialization code for `BlockchainService` in `graph-service` with the rest of the services' implementations (missed in previous PR)

Closes #419 