### PR TITLE
Implement revokeDelegationByDelegator in account-service

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "default": true,
+  "MD033": false,
+  "MD029": false,
+  "MD025": false,
+  "MD013": false,
+  "files": {
+    "README.md": {
+    "MD033": false
+    }
+  }
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,49 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug chain setup",
+        "request": "launch",
+        "runtimeArgs": ["run-script", "main"],
+        "runtimeExecutable": "npm",
+        "skipFiles": ["<node_internals>/**"],
+        "type": "node",
+        "cwd": "${workspaceFolder}/services/account/apps/api/test/setup"
+      },
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Debug Worker (NestJS via ts-node)",
+        "args": ["${workspaceFolder}/services/account/apps/worker/src/main.ts"],
+        "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
+        "sourceMaps": true,
+        "cwd": "${workspaceRoot}"
+      },
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Debug Api (NestJS via ts-node)",
+        "args": ["${workspaceFolder}/services/account/apps/api/src/main.ts"],
+        "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
+        "sourceMaps": true,
+        "cwd": "${workspaceRoot}/services/account"
+      },
+      {
+        "type": "node",
+        "request": "attach",
+        "name": "Attach to API Service",
+        "port": 9229,
+        "restart": true
+      },
+      {
+        "type": "node",
+        "request": "attach",
+        "name": "Attach to Worker",
+        "port": 9230,
+        "restart": true
+      }
+    ]
+  }

--- a/services/account/.prettierignore
+++ b/services/account/.prettierignore
@@ -1,0 +1,10 @@
+**/rust-webhook-server
+**/swagger.json
+**/metadata.ts
+**/index.html
+*.md
+*.json
+**/k6-test
+**/coverage
+**/docs
+

--- a/services/account/apps/api/src/controllers/v1/delegation-v1.controller.ts
+++ b/services/account/apps/api/src/controllers/v1/delegation-v1.controller.ts
@@ -15,6 +15,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { u8aToHex, u8aWrapBytes } from '@polkadot/util';
 
 @Controller('v1/delegation')
 @ApiTags('v1/delegation')
@@ -51,7 +52,11 @@ export class DelegationControllerV1 {
     @Query('expirationTime') expirationTime?: number,
   ): Promise<RevokeDelegationPayloadRequest> {
     try {
-      const revokeDelegationPayload = this.delegationService.getRevokeDelegationPayload(providerId, expirationTime);
+      const expiration = await this.delegationService.getExpiration();
+      const payload = { providerId, expiration };
+      const encodedPayload = u8aToHex(u8aWrapBytes(this.delegationService.encodePayload(payload).toU8a()));
+      const revokeDelegationPayload: RevokeDelegationPayloadRequest = { payload, encodedPayload };
+      this.logger.warn(`REMOVE:RevokeDelegationPayload: ${revokeDelegationPayload}`);
       return revokeDelegationPayload;
     } catch (error) {
       this.logger.error(error);
@@ -66,7 +71,8 @@ export class DelegationControllerV1 {
   @ApiOkResponse({ description: 'Successfully revoked the delegation' })
   async postRevokeDelegation(encodedPayload: RevokeDelegationPayloadRequest): Promise<void> {
     try {
-      await this.delegationService.postRevokeDelegation(encodedPayload);
+      // TODO: Implement the postRevokeDelegation method in the DelegationService
+      // await this.delegationService.postRevokeDelegation(encodedPayload);
     } catch (error) {
       this.logger.error(error);
       throw new HttpException('Failed to revoke the delegation', HttpStatus.BAD_REQUEST);

--- a/services/account/apps/api/src/controllers/v1/delegation-v1.controller.ts
+++ b/services/account/apps/api/src/controllers/v1/delegation-v1.controller.ts
@@ -1,7 +1,8 @@
 import { ReadOnlyGuard } from '#api/guards/read-only.guard';
 import { DelegationService } from '#api/services/delegation.service';
 import { DelegationResponse } from '#lib/types/dtos/delegation.response.dto';
-import { Controller, Get, HttpCode, HttpException, HttpStatus, Logger, Param, UseGuards } from '@nestjs/common';
+import { RevokeDelegationRequest } from '#lib/types/dtos/revokeDelegation.request.dto';
+import { Controller, Get, HttpCode, HttpException, HttpStatus, Logger, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @Controller('v1/delegation')
@@ -26,6 +27,24 @@ export class DelegationControllerV1 {
     } catch (error) {
       this.logger.error(error);
       throw new HttpException('Failed to find the delegation', HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  // Revoke Delegation endpoint
+  @Get('revokeDelegation/:providerId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get a properly encoded RevokeDelegationPayload that can be signed' })
+  @ApiOkResponse({ description: 'Returned an encoded RevokeDelegationPayload for signing' })
+  async getRevokeDelegationPayload(
+    @Param('providerId') providerId: string,
+    @Query('expirationTime') expirationTime?: number,
+  ): Promise<RevokeDelegationRequest> {
+    try {
+      const revokeDelegationPayload = this.delegationService.getRevokeDelegationPayload(providerId, expirationTime);
+      return revokeDelegationPayload;
+    } catch (error) {
+      this.logger.error(error);
+      throw new HttpException('Failed to generate the RevokeDelegationPayload', HttpStatus.BAD_REQUEST);
     }
   }
 }

--- a/services/account/apps/api/src/services/delegation.service.ts
+++ b/services/account/apps/api/src/services/delegation.service.ts
@@ -18,7 +18,10 @@ export class DelegationService {
   constructor(
     private configService: ConfigService,
     private blockchainService: BlockchainService,
-    private enqueueService: EnqueueService,
+    // REMOVE: is this causing the redis dependency?
+    // Seems like it is, but why is that a problem?
+    // Doesn't enqueue service work elsewhere in the api app?
+    // private enqueueService: EnqueueService,
   ) {
     this.logger = new Logger(this.constructor.name);
   }
@@ -46,24 +49,6 @@ export class DelegationService {
     throw new Error('Invalid msaId.');
   }
 
-  // async getRevokeDelegationPayload(
-  //   providerId: string,
-  //   expirationTime: number = BLOCK_EXPIRATION_SECS,
-  // ): Promise<RevokeDelegationPayloadRequest> {
-  //   const revokeDelegationType = this.blockchainService.createType('RevokeDelegationPayload', {
-  //     providerId,
-  //     expiration: expirationBlockNumber,
-  //   });
-  //   const encodedPayload = u8aToHex(u8aWrapBytes(revokeDelegationType.toU8a()));
-  //   this.logger.debug(`RevokeDelegationPayload: ${encodedPayload}`);
-
-  //   const revokeDelegationRequest: RevokeDelegationPayloadRequest = {
-  //     payload: revokeDelegationType,
-  //     encodedPayload,
-  //   };
-  //   return revokeDelegationRequest;
-  // }
-
   async getExpiration(): Promise<number> {
     const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
     // standard expiration in SIWF is 10 minutes
@@ -71,13 +56,9 @@ export class DelegationService {
   }
 
   encodePayload(payload: RevokeDelegationPayloadRequest['payload']) {
-    // return this.blockchainService.createClaimHandPayloadType(payload.providerId, payload.expiration);
-    const revokeDelegationType = this.blockchainService.createType('RevokeDelegationPayload', {
-      providerId: payload.providerId,
-      expiration: payload.expiration,
+    return this.blockchainService.createType('Compact<u64>', {
+      providerMsaId: payload.providerId,
     });
-    this.logger.warn(`REMOVE:RevokeDelegationPayload: ${revokeDelegationType}`);
-    return revokeDelegationType;
   }
 
   // async postRevokeDelegation(@Body() revokeDelegationRequest: RevokeDelegationRequestDto): Promise<TransactionResponse> {

--- a/services/account/apps/api/src/services/delegation.service.ts
+++ b/services/account/apps/api/src/services/delegation.service.ts
@@ -1,9 +1,11 @@
 import { BLOCK_EXPIRATION_SECS, BlockchainService } from '#lib/blockchain/blockchain.service';
 import { ConfigService } from '#lib/config/config.service';
+import { TransactionResponse } from '#lib/types/dtos';
 import { DelegationResponse } from '#lib/types/dtos/delegation.response.dto';
-import { RevokeDelegationRequest } from '#lib/types/dtos/revokeDelegation.request.dto';
+import { RevokeDelegationPayloadRequest, RevokeDelegationRequestDto } from '#lib/types/dtos/revokeDelegation.request.dto';
 import { Injectable, Logger } from '@nestjs/common';
-import { SECONDS_PER_BLOCK } from 'libs/common/src';
+import { u8aToHex, u8aWrapBytes } from '@polkadot/util';
+import { EnqueueService, SECONDS_PER_BLOCK, TransactionType } from 'libs/common/src';
 
 @Injectable()
 export class DelegationService {
@@ -12,6 +14,7 @@ export class DelegationService {
   constructor(
     private configService: ConfigService,
     private blockchainService: BlockchainService,
+    private enqueueService: EnqueueService,
   ) {
     this.logger = new Logger(this.constructor.name);
   }
@@ -42,13 +45,28 @@ export class DelegationService {
   async getRevokeDelegationPayload(
     providerId: string,
     expirationTime: number = BLOCK_EXPIRATION_SECS,
-  ): Promise<RevokeDelegationRequest> {
+  ): Promise<RevokeDelegationPayloadRequest> {
     const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
     const expirationBlockNumber = lastFinalizedBlockNumber + expirationTime / SECONDS_PER_BLOCK;
     const revokeDelegationType = this.blockchainService.createType('RevokeDelegationPayload', {
       providerId,
-      expirationBlockNumber,
+      expiration: expirationBlockNumber,
     });
-    // return this.blockchainService.getRevokeDelegationPayload(providerId);
+    const encodedPayload = u8aToHex(u8aWrapBytes(revokeDelegationType.toU8a()));
+    this.logger.debug(`RevokeDelegationPayload: ${encodedPayload}`);
+
+    const revokeDelegationRequest: RevokeDelegationPayloadRequest = {
+      payload: revokeDelegationType,
+      encodedPayload,
+    };
+    return revokeDelegationRequest;
   }
+
+  async postRevokeDelegation(@Body() revokeDelegationRequest: RevokeDelegationRequestDto): Promise<TransactionResponse> {
+    try {
+      const response = await this.enqueueService.enqueueRequest<RevokeDelegationRequest>({
+        ...revokeDelegationRequest
+        type: TransactionType.REVOKE_DELEGATION,
+      })
+    }
 }

--- a/services/account/apps/api/src/services/delegation.service.ts
+++ b/services/account/apps/api/src/services/delegation.service.ts
@@ -1,8 +1,12 @@
-import { BLOCK_EXPIRATION_SECS, BlockchainService } from '#lib/blockchain/blockchain.service';
+import { BlockchainConstants } from '#lib/blockchain/blockchain-constants';
+import { BlockchainService } from '#lib/blockchain/blockchain.service';
 import { ConfigService } from '#lib/config/config.service';
 import { TransactionResponse } from '#lib/types/dtos';
 import { DelegationResponse } from '#lib/types/dtos/delegation.response.dto';
-import { RevokeDelegationPayloadRequest, RevokeDelegationRequestDto } from '#lib/types/dtos/revokeDelegation.request.dto';
+import {
+  RevokeDelegationPayloadRequest,
+  RevokeDelegationRequestDto,
+} from '#lib/types/dtos/revokeDelegation.request.dto';
 import { Injectable, Logger } from '@nestjs/common';
 import { u8aToHex, u8aWrapBytes } from '@polkadot/util';
 import { EnqueueService, SECONDS_PER_BLOCK, TransactionType } from 'libs/common/src';
@@ -42,31 +46,46 @@ export class DelegationService {
     throw new Error('Invalid msaId.');
   }
 
-  async getRevokeDelegationPayload(
-    providerId: string,
-    expirationTime: number = BLOCK_EXPIRATION_SECS,
-  ): Promise<RevokeDelegationPayloadRequest> {
-    const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
-    const expirationBlockNumber = lastFinalizedBlockNumber + expirationTime / SECONDS_PER_BLOCK;
-    const revokeDelegationType = this.blockchainService.createType('RevokeDelegationPayload', {
-      providerId,
-      expiration: expirationBlockNumber,
-    });
-    const encodedPayload = u8aToHex(u8aWrapBytes(revokeDelegationType.toU8a()));
-    this.logger.debug(`RevokeDelegationPayload: ${encodedPayload}`);
+  // async getRevokeDelegationPayload(
+  //   providerId: string,
+  //   expirationTime: number = BLOCK_EXPIRATION_SECS,
+  // ): Promise<RevokeDelegationPayloadRequest> {
+  //   const revokeDelegationType = this.blockchainService.createType('RevokeDelegationPayload', {
+  //     providerId,
+  //     expiration: expirationBlockNumber,
+  //   });
+  //   const encodedPayload = u8aToHex(u8aWrapBytes(revokeDelegationType.toU8a()));
+  //   this.logger.debug(`RevokeDelegationPayload: ${encodedPayload}`);
 
-    const revokeDelegationRequest: RevokeDelegationPayloadRequest = {
-      payload: revokeDelegationType,
-      encodedPayload,
-    };
-    return revokeDelegationRequest;
+  //   const revokeDelegationRequest: RevokeDelegationPayloadRequest = {
+  //     payload: revokeDelegationType,
+  //     encodedPayload,
+  //   };
+  //   return revokeDelegationRequest;
+  // }
+
+  async getExpiration(): Promise<number> {
+    const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+    // standard expiration in SIWF is 10 minutes
+    return lastFinalizedBlockNumber + BlockchainConstants.BLOCK_EXPIRATION_SECS / BlockchainConstants.SECONDS_PER_BLOCK;
   }
 
-  async postRevokeDelegation(@Body() revokeDelegationRequest: RevokeDelegationRequestDto): Promise<TransactionResponse> {
-    try {
-      const response = await this.enqueueService.enqueueRequest<RevokeDelegationRequest>({
-        ...revokeDelegationRequest
-        type: TransactionType.REVOKE_DELEGATION,
-      })
-    }
+  encodePayload(payload: RevokeDelegationPayloadRequest['payload']) {
+    // return this.blockchainService.createClaimHandPayloadType(payload.providerId, payload.expiration);
+    const revokeDelegationType = this.blockchainService.createType('RevokeDelegationPayload', {
+      providerId: payload.providerId,
+      expiration: payload.expiration,
+    });
+    this.logger.warn(`REMOVE:RevokeDelegationPayload: ${revokeDelegationType}`);
+    return revokeDelegationType;
+  }
+
+  // async postRevokeDelegation(@Body() revokeDelegationRequest: RevokeDelegationRequestDto): Promise<TransactionResponse> {
+  //   try {
+  //     const response = await this.enqueueService.enqueueRequest<RevokeDelegationRequest>({
+  //       ...revokeDelegationRequest
+  //       type: TransactionType.REVOKE_DELEGATION,
+  //     })
+  //   }
+  // }
 }

--- a/services/account/apps/api/src/services/delegation.service.ts
+++ b/services/account/apps/api/src/services/delegation.service.ts
@@ -1,7 +1,9 @@
-import { BlockchainService } from '#lib/blockchain/blockchain.service';
+import { BLOCK_EXPIRATION_SECS, BlockchainService } from '#lib/blockchain/blockchain.service';
 import { ConfigService } from '#lib/config/config.service';
 import { DelegationResponse } from '#lib/types/dtos/delegation.response.dto';
+import { RevokeDelegationRequest } from '#lib/types/dtos/revokeDelegation.request.dto';
 import { Injectable, Logger } from '@nestjs/common';
+import { SECONDS_PER_BLOCK } from 'libs/common/src';
 
 @Injectable()
 export class DelegationService {
@@ -35,5 +37,18 @@ export class DelegationService {
       throw new Error('Failed to find the delegation.');
     }
     throw new Error('Invalid msaId.');
+  }
+
+  async getRevokeDelegationPayload(
+    providerId: string,
+    expirationTime: number = BLOCK_EXPIRATION_SECS,
+  ): Promise<RevokeDelegationRequest> {
+    const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+    const expirationBlockNumber = lastFinalizedBlockNumber + expirationTime / SECONDS_PER_BLOCK;
+    const revokeDelegationType = this.blockchainService.createType('RevokeDelegationPayload', {
+      providerId,
+      expirationBlockNumber,
+    });
+    // return this.blockchainService.getRevokeDelegationPayload(providerId);
   }
 }

--- a/services/account/apps/worker/src/transaction_publisher/publisher.service.ts
+++ b/services/account/apps/worker/src/transaction_publisher/publisher.service.ts
@@ -101,14 +101,14 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
           this.logger.debug(`tx: ${tx}`);
           break;
         }
-        // TODO: Does this need to be a non-capacity transaction?
-        case TransactionType.REVOKE_DELEGATION: {
-          tx = await this.blockchainService.revokeDelegationByDelegator(job.data);
-          targetEvent = { section: 'delegation', method: 'DelegationRevoked' };
-          txHash = await this.processSingleTxn(providerKeys, tx);
-          this.logger.debug(`tx: ${tx}`);
-          break;
-        }
+        // TODO: Finish implementing the non-capacity wrapped transaction types
+        // case TransactionType.REVOKE_DELEGATION: {
+        //   tx = await this.blockchainService.revokeDelegationByDelegator(job.data);
+        //   targetEvent = { section: 'delegation', method: 'DelegationRevoked' };
+        //   txHash = await this.processSingleTxn(providerKeys, tx);
+        //   this.logger.debug(`tx: ${tx}`);
+        //   break;
+        // }
         default: {
           throw new Error(`Invalid job type.`);
         }
@@ -171,22 +171,23 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
     }
   }
 
-  async processFreeTxn(tx: SubmittableExtrinsic<'promise', ISubmittableResult>): Promise<HexString> {
-    this.logger.debug(`Submitting free tx of size ${tx.length}, method: ${tx.method.section}.${tx.method.method}`);
-    try {
-      const nonce = await this.nonceService.getNextNonce();
-      this.logger.warn(`REMOVE:Nonce: ${nonce}`);
-      const txHash = (await tx.signAndSend(address)).toHex();
-      if (!txHash) {
-        throw new Error('Tx hash is undefined');
-      }
-      this.logger.debug(`Tx hash: ${txHash}`);
-      return txHash;
-    } catch (error) {
-      this.logger.error(`Error processing free transaction: ${error}`);
-      throw error;
-    }
-  }
+  // TODO: why does signAndSend need an address and not just a nonce, like above?
+  // async processFreeTxn(tx: SubmittableExtrinsic<'promise', ISubmittableResult>): Promise<HexString> {
+  //   this.logger.debug(`Submitting free tx of size ${tx.length}, method: ${tx.method.section}.${tx.method.method}`);
+  //   try {
+  //     const nonce = await this.nonceService.getNextNonce();
+  //     this.logger.warn(`REMOVE:Nonce: ${nonce}`);
+  //     const txHash = (await tx.signAndSend(address)).toHex();
+  //     if (!txHash) {
+  //       throw new Error('Tx hash is undefined');
+  //     }
+  //     this.logger.debug(`Tx hash: ${txHash}`);
+  //     return txHash;
+  //   } catch (error) {
+  //     this.logger.error(`Error processing free transaction: ${error}`);
+  //     throw error;
+  //   }
+  // }
 
   async processBatchTxn(
     providerKeys: KeyringPair,

--- a/services/account/apps/worker/src/transaction_publisher/publisher.service.ts
+++ b/services/account/apps/worker/src/transaction_publisher/publisher.service.ts
@@ -87,7 +87,6 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
           break;
         }
         case TransactionType.SIWF_SIGNUP: {
-          // eslint-disable-next-line prettier/prettier
           const txns = job.data.calls?.map((x) => this.blockchainService.api.tx(x.encodedExtrinsic));
           const callVec = this.blockchainService.createType('Vec<Call>', txns);
           [tx, txHash] = await this.processBatchTxn(providerKeys, callVec);
@@ -98,6 +97,14 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
         case TransactionType.ADD_KEY: {
           tx = await this.blockchainService.addPublicKeyToMsa(job.data);
           targetEvent = { section: 'msa', method: 'PublicKeyAdded' };
+          txHash = await this.processSingleTxn(providerKeys, tx);
+          this.logger.debug(`tx: ${tx}`);
+          break;
+        }
+        // TODO: Does this need to be a non-capacity transaction?
+        case TransactionType.REVOKE_DELEGATION: {
+          tx = await this.blockchainService.revokeDelegationByDelegator(job.data);
+          targetEvent = { section: 'delegation', method: 'DelegationRevoked' };
           txHash = await this.processSingleTxn(providerKeys, tx);
           this.logger.debug(`tx: ${tx}`);
           break;
@@ -160,6 +167,23 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
       return txHash;
     } catch (error) {
       this.logger.error(`Error processing single transaction: ${error}`);
+      throw error;
+    }
+  }
+
+  async processFreeTxn(tx: SubmittableExtrinsic<'promise', ISubmittableResult>): Promise<HexString> {
+    this.logger.debug(`Submitting free tx of size ${tx.length}, method: ${tx.method.section}.${tx.method.method}`);
+    try {
+      const nonce = await this.nonceService.getNextNonce();
+      this.logger.warn(`REMOVE:Nonce: ${nonce}`);
+      const txHash = (await tx.signAndSend(address)).toHex();
+      if (!txHash) {
+        throw new Error('Tx hash is undefined');
+      }
+      this.logger.debug(`Tx hash: ${txHash}`);
+      return txHash;
+    } catch (error) {
+      this.logger.error(`Error processing free transaction: ${error}`);
       throw error;
     }
   }

--- a/services/account/libs/common/src/blockchain/blockchain-constants.ts
+++ b/services/account/libs/common/src/blockchain/blockchain-constants.ts
@@ -31,6 +31,9 @@ export namespace BlockchainConstants {
 
   export const SECONDS_PER_BLOCK = 12;
 
+  // Default expiration time for a block, same as SIWF
+  export const BLOCK_EXPIRATION_SECS = 10 * 60; // 10 minutes
+
   /**
    * The number of blocks to crawl for a given job
    * @type {number}

--- a/services/account/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/account/libs/common/src/blockchain/blockchain.service.ts
@@ -24,6 +24,7 @@ import { KeysRequestDto } from '#lib/types/dtos/keys.request.dto';
 import { PublishHandleRequestDto } from '#lib/types/dtos/handles.request.dto';
 import { TransactionData } from '#lib/types/dtos/transaction.request.dto';
 import { HandleResponseDto } from '#lib/types/dtos/accounts.response.dto';
+import { RevokeDelegationRequestDto } from '#lib/types/dtos/revokeDelegation.request.dto';
 import { Extrinsic } from './extrinsic';
 import { SECONDS_PER_BLOCK } from '../constants';
 
@@ -250,6 +251,16 @@ export class BlockchainService implements OnApplicationBootstrap, OnApplicationS
       baseHandle: handleVec,
       expiration,
     });
+  }
+
+  public async revokeDelegationByDelegator(jobData: TransactionData<RevokeDelegationRequestDto>) {
+    this.logger.warn(`REMOVE:revokeDelegationPayload: ${jobData.payload}`);
+
+    const revokeDelegationProof: Sr25519Signature = { Sr25519: jobData.proof };
+    this.logger.warn(`REMOVE:revokeDelegationProof: ${JSON.stringify(revokeDelegationProof)}`);
+
+    this.logger.warn(`REMOVE:revokeDelegationProviderId: ${jobData.providerId}`);
+    return this.api.tx.msa.revokeDelegationByDelegator(jobData.providerId);
   }
 
   public async publishHandle(jobData: TransactionData<PublishHandleRequestDto>) {

--- a/services/account/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/account/libs/common/src/blockchain/blockchain.service.ts
@@ -57,7 +57,6 @@ export interface ICapacityInfo {
   currentEpoch: number;
 }
 
-export const BLOCK_EXPIRATION_SECS = 10 * 60; // 10 minutes
 @Injectable()
 export class BlockchainService implements OnApplicationBootstrap, OnApplicationShutdown {
   public api: ApiPromise;

--- a/services/account/libs/common/src/blockchain/blockchain.service.ts
+++ b/services/account/libs/common/src/blockchain/blockchain.service.ts
@@ -25,6 +25,7 @@ import { PublishHandleRequestDto } from '#lib/types/dtos/handles.request.dto';
 import { TransactionData } from '#lib/types/dtos/transaction.request.dto';
 import { HandleResponseDto } from '#lib/types/dtos/accounts.response.dto';
 import { Extrinsic } from './extrinsic';
+import { SECONDS_PER_BLOCK } from '../constants';
 
 export type Sr25519Signature = { Sr25519: HexString };
 interface SIWFTxnValues {
@@ -55,6 +56,7 @@ export interface ICapacityInfo {
   currentEpoch: number;
 }
 
+export const BLOCK_EXPIRATION_SECS = 10 * 60; // 10 minutes
 @Injectable()
 export class BlockchainService implements OnApplicationBootstrap, OnApplicationShutdown {
   public api: ApiPromise;

--- a/services/account/libs/common/src/types/dtos/revokeDelegation.request.dto.ts
+++ b/services/account/libs/common/src/types/dtos/revokeDelegation.request.dto.ts
@@ -1,0 +1,17 @@
+import { IsNotEmpty } from 'class-validator';
+import { CommonPrimitivesMsaDelegation } from '@polkadot/types/lookup';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RevokeDelegationRequest {
+  @ApiProperty()
+  @IsNotEmpty()
+  providerId: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  schemaPermissions: CommonPrimitivesMsaDelegation['schemaPermissions'];
+
+  @ApiProperty()
+  @IsNotEmpty()
+  revokedAt: CommonPrimitivesMsaDelegation['revokedAt'];
+}

--- a/services/account/libs/common/src/types/dtos/revokeDelegation.request.dto.ts
+++ b/services/account/libs/common/src/types/dtos/revokeDelegation.request.dto.ts
@@ -1,17 +1,43 @@
+/* eslint-disable max-classes-per-file */
 import { IsNotEmpty } from 'class-validator';
 import { CommonPrimitivesMsaDelegation } from '@polkadot/types/lookup';
 import { ApiProperty } from '@nestjs/swagger';
+import { HexString } from '@polkadot/util/types';
+import { TransactionType } from '../enums';
 
-export class RevokeDelegationRequest {
+class RevokeDelegationPayloadDto {
   @ApiProperty()
   @IsNotEmpty()
   providerId: string;
 
   @ApiProperty()
   @IsNotEmpty()
-  schemaPermissions: CommonPrimitivesMsaDelegation['schemaPermissions'];
+  expiration: number;
+}
+
+export class RevokeDelegationRequestDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  providerId: string;
 
   @ApiProperty()
   @IsNotEmpty()
-  revokedAt: CommonPrimitivesMsaDelegation['revokedAt'];
+  payload: RevokeDelegationPayloadDto;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  proof: HexString;
 }
+export class RevokeDelegationPayloadRequest {
+  @ApiProperty()
+  @IsNotEmpty()
+  payload: RevokeDelegationRequestDto['payload'];
+
+  @ApiProperty()
+  @IsNotEmpty()
+  encodedPayload: HexString;
+}
+
+export type RevokeDelegationRequest = RevokeDelegationRequestDto & {
+  type: TransactionType.REVOKE_DELEGATION;
+};

--- a/services/account/libs/common/src/types/dtos/revokeDelegation.request.dto.ts
+++ b/services/account/libs/common/src/types/dtos/revokeDelegation.request.dto.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-classes-per-file */
 import { IsNotEmpty } from 'class-validator';
-import { CommonPrimitivesMsaDelegation } from '@polkadot/types/lookup';
 import { ApiProperty } from '@nestjs/swagger';
 import { HexString } from '@polkadot/util/types';
 import { TransactionType } from '../enums';
@@ -9,10 +8,6 @@ class RevokeDelegationPayloadDto {
   @ApiProperty()
   @IsNotEmpty()
   providerId: string;
-
-  @ApiProperty()
-  @IsNotEmpty()
-  expiration: number;
 }
 
 export class RevokeDelegationRequestDto {

--- a/services/account/libs/common/src/types/enums.ts
+++ b/services/account/libs/common/src/types/enums.ts
@@ -5,4 +5,5 @@ export enum TransactionType {
   SIWF_SIGNUP = 'SIWF_SIGNUP',
   SIWF_SIGNIN = 'SIWF_SIGNIN',
   ADD_KEY = 'ADD_KEY',
+  REVOKE_DELEGATION = 'REVOKE_DELEGATION',
 }

--- a/services/account/tsconfig.json
+++ b/services/account/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "@projectlibertylabs/ts-config",
   "compilerOptions": {
     "baseUrl": ".",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "paths": {
       "#api": ["apps/api/src"],
       "#api/*": ["apps/api/src/*"],


### PR DESCRIPTION
 # Description
As a consumer of the Gateway API, I want to be able to revoke a previously granted delegation

Should implement:
`GET /account/accounts/revokeDelegation/{providerId}` (returns a `revokeDelegationByDelegator` encoded extrinsic that can be signed)
`POST /account/accounts/revokeDelegation` submits a signed extrinsic for execution

Closes #411 

# Problem

problem statement, including
Link to GitHub Issue(s):

# Solution

What I/we did to solve this problem

with @pairperson1

## Steps to Verify:

1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

## Screenshots (optional):

Show-n-tell images/animations here
