### PR TITLE
wip: messing with signatures

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - redis_data:/data/redis
 
   frequency:
-    image: frequencychain/standalone-node:v1.13.0-rc3
+    image: dsnp/instant-seal-node-with-deployed-schemas:latest
     # We need to specify the platform because it's the only image
     # built by Frequency at the moment, and auto-pull won't work otherwise
     platform: linux/amd64
@@ -63,7 +63,7 @@ services:
     # Other options you may want to add depending on your test scenario.
     environment:
       - SEALING_MODE=instant
-#      - SEALING_INTERVAL=12
+      # - SEALING_INTERVAL=12
     #   - CREATE_EMPTY_BLOCKS=true
     # The 'command' may contain additional CLI options to the Frequency node,
     # such as:

--- a/services/account/apps/api/test/accounts.controller.spec.ts
+++ b/services/account/apps/api/test/accounts.controller.spec.ts
@@ -115,7 +115,7 @@ describe('Account Controller', () => {
   //   ('(GET) /v1/accounts/retireMsa/:accountId get payload for retireMsa, given an invalid accountId', async () => {})
   // );
 
-  it('(POST) /v1/accounts/retireMsa post retireMsa', async () => {
+  it.only('(POST) /v1/accounts/retireMsa post retireMsa', async () => {
     const { keypair } = users[0];
     const accountId = keypair.address;
     const getRetireMsaResponse = await request(app.getHttpServer()).get(`/v1/accounts/retireMsa/${accountId}`);

--- a/services/account/apps/api/test/setup/test-sign-ext.ts
+++ b/services/account/apps/api/test/setup/test-sign-ext.ts
@@ -9,6 +9,7 @@ const FREQUENCY_URL = process.env.FREQUENCY_URL || 'ws://127.0.0.1:9944';
 
 async function main() {
   await cryptoWaitReady();
+  log.setLevel('trace');
   console.log('Connecting...');
   await initialize(FREQUENCY_URL);
   log.setLevel('trace');
@@ -29,6 +30,7 @@ async function retireMsa() {
       await tx.signAsync(signerAddress, {
         signer: {
           signRaw: (raw) => {
+            console.log('signRaw called with:', raw);
             signRaw = raw;
             throw new Error('Stop here');
           },
@@ -40,36 +42,74 @@ async function retireMsa() {
   };
 
   const getSignerForRawSignature = (result: SignerResult): Signer => ({
-    signRaw: () => Promise.resolve(result),
+    signRaw: (raw) => {
+      console.log('signRaw function called with:', raw);
+      return Promise.resolve(result);
+    },
   });
 
   const tx = ExtrinsicHelper.apiPromise.tx.msa.retireMsa();
 
   const payload = await getRawPayloadForSigning(tx, aliceKeys.address);
-
   console.log('payload:', payload);
 
   const { data } = payload;
-  console.log('data:', data);
+  // Confirmed: Prefix is not needed for signing, the payload and signature can be verified with polkadot-js
+  const prefixedData = data;
+  console.log('prefixedData:', prefixedData);
 
-  // TODO: make into signer result
-  const sig: SignerResult = { id: 1, signature: u8aToHex(aliceKeys.sign(data)) };
-  console.log('sig:', sig);
+  // 3. From github, use the withType option to sign the payload to get the id = 01 for the enum error
+  const signature = aliceKeys.sign(prefixedData, { withType: true });
+  // Confirmed: this signature is correct and can be verified with polkadot-js, if you remove the prefix 0x01
+  console.log('signature:', u8aToHex(signature));
 
-  const signer = getSignerForRawSignature(sig);
+  const prefixedSignature: SignerResult = { id: 1, signature: u8aToHex(signature) };
+  console.log('prefixedSignature:', prefixedSignature);
+
+  const signer = getSignerForRawSignature(prefixedSignature);
   console.log('signer:', signer);
 
-  const transaction = await tx.signAsync(aliceKeys.address, { signer });
+  const { nonce } = await ExtrinsicHelper.apiPromise.query.system.account(aliceKeys.address);
+  console.log('nonce:', nonce.toHuman());
 
-  console.log('did it sign???');
-  // const transaction = await ExtrinsicHelper.apiPromise.tx();
+  // Adding signer after confirming that the payload and signature are correct
+  // Error: createType(ExtrinsicSignature):: Unable to create Enum via index 92, in Ed25519, Sr25519, Ecdsa
+  // TODO: Something is wrong with signer, at least it's not doing what we want it to, which is close the circle
+  // UPDATE: This error is solved by using the withType option in the sign function
+  //   However, now the error is Invalid Transaction: Custom error: 2
+  const submittableExtrinsic = await tx.signAsync(aliceKeys.address, { nonce, signer });
+  // Here we can examine the signature, which should match the above signature
+  // However, it a signature that can be verified with polkadot-js and it does not have the prefix 0x01
+  console.log('submittableExtrinsic.signature:', submittableExtrinsic.signature.toHex());
+  // 4. Attempt to add the signature to the transaction
+  //    Result: the signature does not change
+  // 5. Attempt to add the prefix to the signature
+  //    Result: Transaction has a bad signature
+  //            It seems like the signature might be correct as-is, but there is another problem with the transaction
+  // const signatureWithPrefix = new Uint8Array([0x01, ...Array.from(signature)]);
+  // console.log('signatureWithPrefix:', u8aToHex(signatureWithPrefix));
+
+  // 6. Remove Attempt to add the signature to the transaction
+  //    Result: Back to Invalid Transaction: Custom error: 2
+  //    Visual examination of the signature shows that it matches the signature from the signAsync call, but it is not prefixed
+  // submittableExtrinsic.addSignature(aliceKeys.addressRaw, u8aToHex(signature), '0x00');
+  // console.log('after addSignature: submittableExtrinsic.signature:', submittableExtrinsic.signature.toHex());
+
+  // 1. Attempt to remove the signer from the signAsync call
+  // const signerPayload = await tx.signAsync(aliceKeys, { nonce, signer: null, era: 0 });
+  // console.log('signerPayload:', signerPayload.data);
+  console.log('Signer Address:', aliceKeys.address);
+
+  // const transaction = ExtrinsicHelper.apiPromise.tx(tx);
+  // console.log('transaction:', transaction);
 
   // console.log('Sending transaction with signature:', u8aToHex(signature));
 
-  // transaction.addSignature(aliceKeys.addressRaw, signature, signerPayload.toPayload());
+  // 2. Attempt to add the signature to the transaction
+  // transaction.addSignature(aliceKeys.addressRaw, u8aToHex(signature), signerPayload.toHex());
 
   await new Promise<void>((resolve, reject) => {
-    transaction.send(({ status, dispatchError }) => {
+    submittableExtrinsic.send(({ status, dispatchError }) => {
       if (dispatchError) {
         console.error('ERROR: ', dispatchError.toHuman());
         reject(dispatchError.toJSON());

--- a/services/account/apps/api/test/setup/test-sign-ext.ts
+++ b/services/account/apps/api/test/setup/test-sign-ext.ts
@@ -3,7 +3,8 @@ import log from 'loglevel';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import Keyring from '@polkadot/keyring';
 import { u8aToHex } from '@polkadot/util';
-import { SignerResult, Signer } from '@polkadot/types/types';
+import { SignerResult, Signer, SignerPayloadRaw, ISubmittableResult } from '@polkadot/types/types';
+import { SubmittableExtrinsic } from '@polkadot/api-base/types';
 
 const FREQUENCY_URL = process.env.FREQUENCY_URL || 'ws://127.0.0.1:9944';
 
@@ -12,7 +13,6 @@ async function main() {
   log.setLevel('trace');
   console.log('Connecting...');
   await initialize(FREQUENCY_URL);
-  log.setLevel('trace');
 
   // eslint-disable-next-line no-use-before-define
   await retireMsa();
@@ -20,21 +20,31 @@ async function main() {
 
 async function retireMsa() {
   await cryptoWaitReady();
-  const aliceKeys = new Keyring({ type: 'sr25519' }).createFromUri('//Alice');
-  // 7. Attempt to retire an MSA for BOB, who is not a provider and only has an msa and nothing else
-  //    Result:  SUCCESS!!!
   const bobKeys = new Keyring({ type: 'sr25519' }).createFromUri('//Bob');
 
+  /**
+   * Retrieves the raw payload for signing a transaction.
+   * Use signAsync to properly encode the payload for signing.
+   * In this case we want the encoded payload for retireMsa, which does not take any arguments.
+   *
+   * @param tx - The transaction object.
+   * @param signerAddress - The address of the signer.
+   * @returns A promise that resolves to the raw payload for signing.
+   */
   // @ts-ignore
-  // eslint-disable-next-line consistent-return
-  const getRawPayloadForSigning = async (tx: any, signerAddress: string): Promise<SignerPayloadRaw> => {
+  const getRawPayloadForSigning = async (
+    tx: SubmittableExtrinsic<'promise', ISubmittableResult>,
+    signerAddress: string,
+    // eslint-disable-next-line consistent-return
+  ): Promise<SignerPayloadRaw> => {
     let signRaw;
     try {
       await tx.signAsync(signerAddress, {
         signer: {
           signRaw: (raw) => {
-            console.log('signRaw called with:', raw);
+            console.log('signRaw called with [raw]:', raw);
             signRaw = raw;
+            // Interrupt the signing process to get the raw payload, as encoded by polkadot-js
             throw new Error('Stop here');
           },
         },
@@ -44,72 +54,53 @@ async function retireMsa() {
     }
   };
 
+  /**
+   * Returns a signer function for a given SignerResult.
+   * Signer will be used to pass our verified signature to the transaction without any mutation.
+   *
+   * @param result - The SignerResult object.
+   * @returns A Signer function that will pass the signature to the transaction without mutation.
+   */
   const getSignerForRawSignature = (result: SignerResult): Signer => ({
     signRaw: (raw) => {
-      console.log('signRaw function called with:', raw);
+      console.log('signRaw function called with [raw]:', raw);
       return Promise.resolve(result);
     },
   });
 
-  const tx = ExtrinsicHelper.apiPromise.tx.msa.retireMsa();
+  // Get the transaction for retireMsa, will be used to get the raw payload for signing
+  const tx: SubmittableExtrinsic<'promise', ISubmittableResult> = ExtrinsicHelper.apiPromise.tx.msa.retireMsa();
 
-  const payload = await getRawPayloadForSigning(tx, bobKeys.address);
-  console.log('payload:', payload);
+  const payload: SignerPayloadRaw = await getRawPayloadForSigning(tx, bobKeys.address);
+  // payload contains the signer address, the encoded data/payload for retireMsa, and the type of the payload
+  console.log('payload: SignerPayloadRaw: ', payload);
 
   const { data } = payload;
-  // Confirmed: Prefix is not needed for signing, the payload and signature can be verified with polkadot-js
-  const prefixedData = data;
-  console.log('prefixedData:', prefixedData);
 
-  // 3. From github, use the withType option to sign the payload to get the id = 01 for the enum error
-  const signature = bobKeys.sign(prefixedData, { withType: true });
+  // From github:https://github.com/polkadot-js/tools/issues/175
+  // Use the withType option to sign the payload to get the prefix 0x01
+  // which specifies the SR25519 type of the signature and avoids getting and error about an enum in the next signAsync step
+  const signature: Uint8Array = bobKeys.sign(data, { withType: true });
   // Confirmed: this signature is correct and can be verified with polkadot-js, if you remove the prefix 0x01
   console.log('signature:', u8aToHex(signature));
 
+  // Construct the SignerResult object
+  // SignerResult is used to get the Signer.signRaw function that will be used to pass the signature to the transaction
   const prefixedSignature: SignerResult = { id: 1, signature: u8aToHex(signature) };
   console.log('prefixedSignature:', prefixedSignature);
 
-  const signer = getSignerForRawSignature(prefixedSignature);
+  const signer: Signer = getSignerForRawSignature(prefixedSignature);
   console.log('signer:', signer);
 
   const { nonce } = await ExtrinsicHelper.apiPromise.query.system.account(bobKeys.address);
   console.log('nonce:', nonce.toHuman());
 
-  // Adding signer after confirming that the payload and signature are correct
-  // Error: createType(ExtrinsicSignature):: Unable to create Enum via index 92, in Ed25519, Sr25519, Ecdsa
-  // TODO: Something is wrong with signer, at least it's not doing what we want it to, which is close the circle
-  // UPDATE: This error is solved by using the withType option in the sign function
-  //   However, now the error is Invalid Transaction: Custom error: 2
+  // Here submittableExtrinsic is the retireMsa transaction
+  // signer uses signRaw to pass the original signature to the transaction
+  // This makes sure that the signature is not mutated in any way
+  // Avoiding tx.addSignature() because it seems to be mutating the signature and causing the transaction to fail
   const submittableExtrinsic = await tx.signAsync(bobKeys.address, { nonce, signer });
-  // Here we can examine the signature, which should match the above signature
-  // However, it a signature that can be verified with polkadot-js and it does not have the prefix 0x01
   console.log('submittableExtrinsic.signature:', submittableExtrinsic.signature.toHex());
-  // 4. Attempt to add the signature to the transaction
-  //    Result: the signature does not change
-  // 5. Attempt to add the prefix to the signature
-  //    Result: Transaction has a bad signature
-  //            It seems like the signature might be correct as-is, but there is another problem with the transaction
-  // const signatureWithPrefix = new Uint8Array([0x01, ...Array.from(signature)]);
-  // console.log('signatureWithPrefix:', u8aToHex(signatureWithPrefix));
-
-  // 6. Remove Attempt to add the signature to the transaction
-  //    Result: Back to Invalid Transaction: Custom error: 2
-  //    Visual examination of the signature shows that it matches the signature from the signAsync call, but it is not prefixed
-  // submittableExtrinsic.addSignature(aliceKeys.addressRaw, u8aToHex(signature), '0x00');
-  // console.log('after addSignature: submittableExtrinsic.signature:', submittableExtrinsic.signature.toHex());
-
-  // 1. Attempt to remove the signer from the signAsync call
-  // const signerPayload = await tx.signAsync(aliceKeys, { nonce, signer: null, era: 0 });
-  // console.log('signerPayload:', signerPayload.data);
-  console.log('Signer Address:', bobKeys.address);
-
-  // const transaction = ExtrinsicHelper.apiPromise.tx(tx);
-  // console.log('transaction:', transaction);
-
-  // console.log('Sending transaction with signature:', u8aToHex(signature));
-
-  // 2. Attempt to add the signature to the transaction
-  // transaction.addSignature(aliceKeys.addressRaw, u8aToHex(signature), signerPayload.toHex());
 
   await new Promise<void>((resolve, reject) => {
     submittableExtrinsic.send(({ status, dispatchError }) => {


### PR DESCRIPTION
# Problem

We can't build a transaction from an encoded payload and submit the signed transaction to the chain.

# Solution

I found a few things in this branch that may be useful:

1. There is a `withType` option that should be `true` to include the 0x01 prefix in a signature.
2. Using `addSignature` on a SubmittableExtrinsic does not change the signature that we used from `signAsync`
3. Invalid Transaction: Custom Error 2 is hopefully something not related to the signature.

with @claireolmstead @wilwade 

