### PR TITLE
Docs Preprocessor fixes for broken embeds

### DIFF
--- a/docs/preprocessor.mjs
+++ b/docs/preprocessor.mjs
@@ -47,9 +47,9 @@ function replaceButtonLinks(chapter) {
 }
 
 function swaggerEmbed(chapter) {
-  const regex = /{{#swagger-embed\s(.+?)}}/;
-  const match = chapter.content.match(regex);
-  if (match) {
+  const regex = /{{#swagger-embed\s(.+?)}}/g;
+  const matches = [...chapter.content.matchAll(regex)];
+  matches.forEach((match) => {
     const swaggerFile = match[1];
     const output = runNpxCommand('openapi-to-md', [swaggerFile]);
     const replaceWith = output
@@ -61,7 +61,7 @@ function swaggerEmbed(chapter) {
       .map((line) => (line.startsWith('#') ? line + '{}' : line))
       .join('\n');
     chapter.content = chapter.content.replace(match[0], replaceWith);
-  }
+  });
   if (chapter.sub_items) {
     chapter.sub_items.forEach((section) => {
       section.Chapter && swaggerEmbed(section.Chapter);
@@ -70,14 +70,14 @@ function swaggerEmbed(chapter) {
 }
 
 function markdownEmbed(chapter) {
-  const regex = /{{#markdown-embed\s(.+?)\s(.+?)}}/;
-  const match = chapter.content.match(regex);
-  if (match) {
+  const regex = /{{#markdown-embed\s(.+?)\s(.+?)}}/g;
+  const matches = [...chapter.content.matchAll(regex)];
+  matches.forEach((match) => {
     const markdownFile = match[1];
     const output = readFileSync(markdownFile, 'utf8');
     const replaceWith = output.split('\n').slice(match[2]).join('\n');
     chapter.content = chapter.content.replace(match[0], replaceWith);
-  }
+  });
   if (chapter.sub_items) {
     chapter.sub_items.forEach((section) => {
       section.Chapter && markdownEmbed(section.Chapter);
@@ -86,15 +86,15 @@ function markdownEmbed(chapter) {
 }
 
 function svgEmbed(chapter) {
-  const regex = /{{#svg-embed\s(.+?)\s(.+?)}}/;
-  const match = chapter.content.match(regex);
-  if (match) {
+  const regex = /{{#svg-embed\s(.+?)\s(.+?)}}/g;
+  const matches = [...chapter.content.matchAll(regex)];
+  matches.forEach((match) => {
     const svgFile = match[1];
     const titleTag = match[2];
     const output = readFileSync(svgFile, 'utf8');
     const replaceWith = `<div class="svg-embed" title="${titleTag}">${output}</div>`;
     chapter.content = chapter.content.replace(match[0], replaceWith);
-  }
+  });
   if (chapter.sub_items) {
     chapter.sub_items.forEach((section) => {
       section.Chapter && svgEmbed(section.Chapter);


### PR DESCRIPTION
# Problem

The preprocessor wasn't replacing all instances on the page.

# Solution

Fixed it.

## Steps to Verify:

1. Pull
1. cd docs
1. mdbook serve
1. See that the two diagrams show up on the main page and the other embeds work
