### PR TITLE
fix: URLs in configs must be strings, not JS URL objects

### DIFF
--- a/apps/account-api/src/api.module.ts
+++ b/apps/account-api/src/api.module.ts
@@ -51,7 +51,7 @@ import apiConfig from './api.config';
       imports: [ConfigModule],
       useFactory: (cacheConf: ICacheConfig) => [
         {
-          url: cacheConf.redisUrl.toString(),
+          url: cacheConf.redisUrl,
           keyPrefix: cacheConf.cacheKeyPrefix,
           maxRetriesPerRequest: null,
         },

--- a/apps/content-publishing-api/src/api.module.ts
+++ b/apps/content-publishing-api/src/api.module.ts
@@ -47,7 +47,7 @@ import ipfsConfig from '#content-publishing-lib/config/ipfs.config';
     CacheModule.forRootAsync({
       useFactory: (cacheConf: ICacheConfig) => [
         {
-          url: cacheConf.redisUrl.toString(),
+          url: cacheConf.redisUrl,
           keyPrefix: cacheConf.cacheKeyPrefix,
         },
       ],

--- a/apps/content-publishing-worker/src/batch_announcer/batch.announcer.spec.ts
+++ b/apps/content-publishing-worker/src/batch_announcer/batch.announcer.spec.ts
@@ -10,7 +10,7 @@ import { IIpfsConfig } from '#content-publishing-lib/config';
 const mockIpfsConfig: IIpfsConfig = {
   ipfsBasicAuthSecret: undefined,
   ipfsBasicAuthUser: undefined,
-  ipfsEndpoint: new URL('http://ipfs.io'),
+  ipfsEndpoint: 'http://ipfs.io',
   ipfsGatewayUrl: 'http://ipfs.io/ipfs/[CID]',
 };
 

--- a/apps/content-publishing-worker/src/request_processor/dsnp.announcement.processor.spec.ts
+++ b/apps/content-publishing-worker/src/request_processor/dsnp.announcement.processor.spec.ts
@@ -17,7 +17,7 @@ const mockQueue = {
 const mockIpfsConfig: IIpfsConfig = {
   ipfsBasicAuthSecret: undefined,
   ipfsBasicAuthUser: undefined,
-  ipfsEndpoint: new URL('http://ipfs.io'),
+  ipfsEndpoint: 'http://ipfs.io',
   ipfsGatewayUrl: 'http://ipfs.io/ipfs/[CID]',
 };
 

--- a/apps/content-publishing-worker/src/worker.module.ts
+++ b/apps/content-publishing-worker/src/worker.module.ts
@@ -27,12 +27,12 @@ import workerConfig from './worker.config';
     CacheModule.forRootAsync({
       useFactory: (blockchainConf, cacheConf) => [
         {
-          url: cacheConf.redisUrl,
+          url: cacheConf.redisUrl.toString(),
           keyPrefix: cacheConf.cacheKeyPrefix,
         },
         {
           namespace: NONCE_SERVICE_REDIS_NAMESPACE,
-          url: cacheConf.redisUrl,
+          url: cacheConf.redisUrl.toString(),
           keyPrefix: `${NONCE_SERVICE_REDIS_NAMESPACE}:${addressFromSeedPhrase(blockchainConf.providerSeedPhrase)}:`,
         },
       ],
@@ -51,7 +51,7 @@ import workerConfig from './worker.config';
       // set this to `true` if you want to emit the removeListener event
       removeListener: false,
       // the maximum amount of listeners that can be assigned to an event
-      maxListeners: 10,
+      maxListeners: 20,
       // show event name in memory leak message when more than maximum amount of listeners is assigned
       verboseMemoryLeak: false,
       // disable throwing uncaughtException if an error event is emitted and it has no listeners

--- a/libs/account-lib/src/cache/cache.config.spec.ts
+++ b/libs/account-lib/src/cache/cache.config.spec.ts
@@ -36,7 +36,7 @@ describe('Cache module config', () => {
     });
 
     it('should get redis url', () => {
-      expect(cacheConf.redisUrl?.toString()).toStrictEqual(ALL_ENV.REDIS_URL?.toString());
+      expect(new URL(cacheConf.redisUrl)).toStrictEqual(new URL(ALL_ENV.REDIS_URL));
     });
 
     it('should get cache key prefix', () => {

--- a/libs/account-lib/src/cache/cache.config.ts
+++ b/libs/account-lib/src/cache/cache.config.ts
@@ -3,7 +3,7 @@ import { registerAs } from '@nestjs/config';
 import Joi from 'joi';
 
 export interface ICacheConfig {
-  redisUrl: URL;
+  redisUrl: string;
   cacheKeyPrefix: string;
 }
 
@@ -11,10 +11,7 @@ export default registerAs('cache', (): ICacheConfig => {
   const configs: JoiUtils.JoiConfig<ICacheConfig> = {
     redisUrl: {
       value: process.env.REDIS_URL,
-      joi: Joi.string()
-        .uri()
-        .required()
-        .custom((v) => new URL(v)),
+      joi: Joi.string().uri().required(),
     },
     cacheKeyPrefix: {
       value: process.env.CACHE_KEY_PREFIX,

--- a/libs/content-publishing-lib/src/cache/cache.config.spec.ts
+++ b/libs/content-publishing-lib/src/cache/cache.config.spec.ts
@@ -36,7 +36,7 @@ describe('Cache module config', () => {
     });
 
     it('should get redis url', () => {
-      expect(cacheConf.redisUrl?.toString()).toStrictEqual(ALL_ENV.REDIS_URL?.toString());
+      expect(new URL(cacheConf.redisUrl)).toStrictEqual(new URL(ALL_ENV.REDIS_URL));
     });
 
     it('should get cache key prefix', () => {

--- a/libs/content-publishing-lib/src/cache/cache.config.ts
+++ b/libs/content-publishing-lib/src/cache/cache.config.ts
@@ -3,7 +3,7 @@ import { registerAs } from '@nestjs/config';
 import Joi from 'joi';
 
 export interface ICacheConfig {
-  redisUrl: URL;
+  redisUrl: string;
   cacheKeyPrefix: string;
 }
 
@@ -11,10 +11,7 @@ export default registerAs('cache', (): ICacheConfig => {
   const configs: JoiUtils.JoiConfig<ICacheConfig> = {
     redisUrl: {
       value: process.env.REDIS_URL,
-      joi: Joi.string()
-        .uri()
-        .required()
-        .custom((v) => new URL(v)),
+      joi: Joi.string().uri().required(),
     },
     cacheKeyPrefix: {
       value: process.env.CACHE_KEY_PREFIX,

--- a/libs/content-publishing-lib/src/config/ipfs.config.spec.ts
+++ b/libs/content-publishing-lib/src/config/ipfs.config.spec.ts
@@ -37,7 +37,7 @@ describe('IPFS config', () => {
     });
 
     it('should get IPFS endpoint', async () => {
-      expect(ipfsConf.ipfsEndpoint).toStrictEqual(new URL(ALL_ENV.IPFS_ENDPOINT));
+      expect(new URL(ipfsConf.ipfsEndpoint)).toStrictEqual(new URL(ALL_ENV.IPFS_ENDPOINT));
     });
 
     it('should get IPFS gateway', async () => {

--- a/libs/content-publishing-lib/src/config/ipfs.config.ts
+++ b/libs/content-publishing-lib/src/config/ipfs.config.ts
@@ -3,7 +3,7 @@ import { registerAs } from '@nestjs/config';
 import Joi from 'joi';
 
 export interface IIpfsConfig {
-  ipfsEndpoint: URL;
+  ipfsEndpoint: string;
   ipfsGatewayUrl: string;
   ipfsBasicAuthUser: string;
   ipfsBasicAuthSecret: string;
@@ -20,10 +20,7 @@ const ipfsConfig = registerAs('ipfs', (): IIpfsConfig => {
   const configs: JoiUtils.JoiConfig<IIpfsConfig> = {
     ipfsEndpoint: {
       value: process.env.IPFS_ENDPOINT,
-      joi: Joi.string()
-        .uri()
-        .required()
-        .custom((v) => new URL(v)),
+      joi: Joi.string().uri().required(),
     },
     ipfsGatewayUrl: {
       value: process.env.IPFS_GATEWAY_URL,

--- a/libs/content-publishing-lib/src/queues/queues.module.ts
+++ b/libs/content-publishing-lib/src/queues/queues.module.ts
@@ -13,7 +13,7 @@ import cacheConfig, { ICacheConfig } from '#content-publishing-lib/cache/cache.c
       useFactory: (cacheConf: ICacheConfig, eventEmitter: EventEmitter2) => {
         // Default map only has 'default' entry; add 'bull' entry
         redisReadyMap.set('bull', false);
-        const connection = new Redis(cacheConf.redisUrl.toString(), { maxRetriesPerRequest: null });
+        const connection = new Redis(cacheConf.redisUrl, { maxRetriesPerRequest: null });
         redisEventsToEventEmitter(connection, eventEmitter, 'bull');
         return {
           connection,

--- a/libs/content-publishing-lib/src/utils/ipfs.client.ts
+++ b/libs/content-publishing-lib/src/utils/ipfs.client.ts
@@ -48,6 +48,8 @@ export class IpfsService {
       authorization: ipfsAuth,
     };
 
+    this.logger.log('Making IPFS pinning request: ', ipfsAdd, headers);
+
     const response = await axios.post(ipfsAdd, form, { headers });
 
     const { data } = response;


### PR DESCRIPTION
# Problem

The recent refactor to configs changed the internal representation of URL config values from string -> JS `URL` object. This caused some problems.

# Solution

Revert to string representation of URLs.