### PR TITLE
bugfix: capacity trx submittion

### DIFF
--- a/apps/graph-api/src/main.ts
+++ b/apps/graph-api/src/main.ts
@@ -61,7 +61,7 @@ async function bootstrap() {
         transform: true,
       }),
     );
-    // TODO: should get replaced with the config
+
     app.useGlobalInterceptors(new TimeoutInterceptor(apiConf.apiTimeoutMs));
     app.useBodyParser('json', { limit: apiConf.apiBodyJsonLimit });
 

--- a/libs/blockchain/src/blockchain-rpc-query.service.ts
+++ b/libs/blockchain/src/blockchain-rpc-query.service.ts
@@ -349,7 +349,7 @@ export class BlockchainRpcQueryService implements OnApplicationBootstrap, OnAppl
   }
 
   public async publishHandle(jobData: TransactionData<PublishHandleRequestDto>) {
-    this.logger.debug(`claimHandlePayload: ${jobData.payload}`);
+    this.logger.debug(`claimHandlePayload: ${JSON.stringify(jobData.payload)}`);
     this.logger.debug(`accountId: ${jobData.accountId}`);
 
     const claimHandleProof: Sr25519Signature = { Sr25519: jobData.proof };

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -157,7 +157,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     const keys = new Keyring({ type: 'sr25519' }).createFromUri(this.config.providerSeedPhrase);
     const nonce = await this.getNextNonce();
     this.logger.debug(`Capacity Wrapped Extrinsic: ${extrinsic.toHuman()}, nonce: ${nonce}`);
-    const txHash = await extrinsic.signAndSend(keys.address, { nonce });
+    const txHash = await extrinsic.signAndSend(keys, { nonce });
     if (!txHash) {
       throw new Error('Tx hash is undefined');
     }
@@ -172,7 +172,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     const keys = new Keyring({ type: 'sr25519' }).createFromUri(this.config.providerSeedPhrase);
     const nonce = await this.getNextNonce();
     this.logger.debug(`Capacity Wrapped Extrinsic: ${extrinsic.toHuman()}, nonce: ${nonce}`);
-    const txHash = await extrinsic.signAndSend(keys.address, { nonce });
+    const txHash = await extrinsic.signAndSend(keys, { nonce });
     if (!txHash) {
       throw new Error('Tx hash is undefined');
     }


### PR DESCRIPTION
# Problem

closes #606 

# Solution

- instead of address we needed to pass the keypair.

# Verification

```
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [BlockchainService] claimHandlePayload: {"baseHandle":"macin","expiration":100}
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [BlockchainService] accountId: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [BlockchainService] claimHandleProof: {"Sr25519":"0x907850f0d8f65794571d403641990820e901208170ca805a8916f4d8b4c9102e817385c528c13c39bc87895c28a24ff7a14c6fe9ba971b362873d89a756cb98d"}
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [TransactionPublisherService] Submitting tx of size 110, nonce:0, method: handles.claimHandle
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [BlockchainService] nextNonce 80
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [BlockchainService] Capacity Wrapped Extrinsic: [object Object], nonce: 80
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [BlockchainService] Tx hash: 0x3ca2415cd2daee34862f1925aabaef6299bef4d573f9a0332af7cd642cb5c527
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [TransactionPublisherService] tx: {"signature":{"signer":{"id":"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"},"signature":{"sr25519":"0x024896f4493b2a892662919a48fd7138accc042be399d2ffc8bad86802a54b34300faa5c12f6ccd34a530479b587ff6036ff4d7203f1e9b640d55a79cd806a83"},"era":{"mortalEra":"0xc400"},"nonce":80,"tip":0},"method":{"callIndex":"0x4100","args":{"call":{"callIndex":"0x4200","args":{"msa_owner_key":"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY","proof":{"sr25519":"0x907850f0d8f65794571d403641990820e901208170ca805a8916f4d8b4c9102e817385c528c13c39bc87895c28a24ff7a14c6fe9ba971b362873d89a756cb98d"},"payload":{"baseHandle":"0x6d6163696e","expiration":100}}}}}}
[Nest] 72593  - 10/09/2024, 3:23:29 PM   DEBUG [TransactionPublisherService] Successful job: {
  "name": "Transaction Job - uxpcOBapxGFrh8l0yWq8ZEZNNW4",
  "data": {
    "accountId": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
    "payload": {
      "baseHandle": "macin",
      "expiration": 100
    },
    "proof": "0x907850f0d8f65794571d403641990820e901208170ca805a8916f4d8b4c9102e817385c528c13c39bc87895c28a24ff7a14c6fe9ba971b362873d89a756cb98d",
    "type": "CREATE_HANDLE",
    "providerId": "1",
    "referenceId": "uxpcOBapxGFrh8l0yWq8ZEZNNW4"
  },
  "opts": {
    "attempts": 1,
    "delay": 0,
    "removeOnFail": false,
    "jobId": "uxpcOBapxGFrh8l0yWq8ZEZNNW4",
    "removeOnComplete": 20
  },
  "id": "uxpcOBapxGFrh8l0yWq8ZEZNNW4",
  "progress": 0,
  "returnvalue": null,
  "stacktrace": [],
  "attemptsStarted": 1,
  "attemptsMade": 0,
  "delay": 0,
  "timestamp": 1728512609840,
  "queueQualifiedName": "account::bull:transactionPublish",
  "processedOn": 1728512609842,
  "token": "5629f329-d951-4031-915f-2928832fc64a:4"
}
[Nest] 72593  - 10/09/2024, 3:23:32 PM VERBOSE [TxnNotifierService] Starting scan from block #13

```
