### PR TITLE
blockchain: event errors

### DIFF
--- a/libs/blockchain/src/blockchain-rpc-query.service.ts
+++ b/libs/blockchain/src/blockchain-rpc-query.service.ts
@@ -467,6 +467,7 @@ export class BlockchainRpcQueryService implements OnApplicationBootstrap, OnAppl
       };
     }
 
+    this.logger.error(`Expected HandleClaimed event but found ${event}`);
     return {} as HandleTxnValues;
   }
 
@@ -488,6 +489,7 @@ export class BlockchainRpcQueryService implements OnApplicationBootstrap, OnAppl
       };
     }
 
+    this.logger.error(`Expected PublicKeyAdded event but found ${event}`);
     return {} as PublicKeyValues;
   }
 
@@ -513,6 +515,7 @@ export class BlockchainRpcQueryService implements OnApplicationBootstrap, OnAppl
       };
     }
 
+    this.logger.error(`Expected ItemizedPageUpdated event but found ${event}`);
     return {} as ItemizedPageUpdated;
   }
 


### PR DESCRIPTION
# Problem

closes #500

# Description
- Was going to throw error but it didn't help since it would cause the block scanning process to be stuck on that certain block and would not be able to recover. The better option seemed like to only log these cases.
