### PR TITLE
update start/stop to use imported bash_functions script

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+BOX_WIDTH=96
+
 ###################################################################################
 #  Wrangle grep because MacOS doesn't come with a PCRE-enabled grep by default.
 #  If we don't find one, disable our "pretty" output function.
@@ -24,11 +26,11 @@ If you're on a Mac, try installing GNU grep:
     brew install grep
 
 EOI
-  read -p 'Press any key to continue: '
+  read -p 'Press any key to continue... '
 
-  OUTPUT=echo
+  OUTPUT='echo -e'
 else
-  OUTPUT='box_text -w 96'
+  OUTPUT="box_text -w ${BOX_WIDTH}"
 fi
 
 ###################################################################################

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+
+###################################################################################
+#  Wrangle grep because MacOS doesn't come with a PCRE-enabled grep by default.
+#  If we don't find one, disable our "pretty" output function.
+###################################################################################
+PCRE_GREP=
+if grep -q -P "foo" 2>/dev/null
+then
+    PCRE_GREP=grep
+else
+    # Grep is not PCRE compatible, check for other greps
+    if command -v ggrep >/dev/null # MacOS Homebrew might have ggrep
+    then
+        PCRE_GREP=ggrep
+    elif command -v prce2grep > /dev/null # MacOS Homebrew could also have pcre2grep
+    then
+        PCRE_GREP=pcre2grep
+    fi
+fi
+
+if [ -z "${PCRE_GREP}" ]
+then
+    cat << EOI
+WARNING: No PCRE-capable 'grep' utility found; pretty terminal output disabled.
+
+If you're on a Mac, try installing GNU grep:
+    brew install grep
+
+EOI
+    OUTPUT=cat
+else
+    OUTPUT=box_text
+fi
+
+###################################################################################
+# yesno
+#
+# Description: Prompt the user with a question requiring a yes/no response. The
+#              prompt will be augmented with "? [y/n]: " (with capitalization reflecting
+#              the default response if the user just hits <Enter>)
+#
+# ${1} - Prompt string
+# ${2} - Default if response is empty (only first character matters)
+###################################################################################
+function yesno() {
+    DEFAULT=Y
+    DEFAULT_STR="Y/n"
+    if [ $# -gt 1 ]; then
+        if [[ ${2} =~ ^[^Yy] ]]; then
+            DEFAULT_STR="y/N"
+            DEFAULT=N
+        fi
+    fi
+    echo
+    read -n 1 -p "${1}? [${DEFAULT_STR}]: "
+    echo
+    if [[ ${REPLY} =~ ^[Yy]$ ]]
+    then
+        return 0
+    elif [ -z "${REPLY}" -a ${DEFAULT} = Y ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+# Internal function to calculate the display width of a string considering some common wide characters
+function display_width() {
+    local str="$1"
+    local width=0
+    local char
+
+    for (( i=0; i<${#str}; i++ )); do
+        char="${str:i:1}"
+        if echo "$char" | ${PCRE_GREP} -P -q '[^\x{00}-\x{7F}]'; then
+            # Emoji or symbol, assume it takes two columns
+            width=$((width + 2))
+        else
+            # Regular character, assume it takes one column
+            width=$((width + 1))
+        fi
+    done
+
+    echo $width
+}
+
+
+
+###################################################################################
+# box_text
+#
+# Description: Output text surrounded by a box; padded with blank lines inside the
+#              top and bottom edges. If TEXT is omitted, it will read from stdin.
+#
+# Usage: box_text [-w <min_width>] [TEXT]
+#
+#    min_width - Pad the output text box to a least min_width characters.
+#                Default: do not pad
+###################################################################################
+box_text() {
+    local input
+    local min_width=0
+
+    # Parse the optional -w argument
+    while getopts ":w:" opt; do
+        case $opt in
+            w)
+                min_width=$OPTARG
+                ;;
+            \?)
+                echo "Invalid option: -$OPTARG" >&2
+                return 1
+                ;;
+            :)
+                echo "Option -$OPTARG requires an argument." >&2
+                return 1
+                ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+
+    if [ -z "$1" ]; then
+        # Read input from stdin if no arguments are provided
+        input=$(cat)
+    else
+        # Use the provided argument as input
+        input="$1"
+    fi
+
+    local IFS=$'\n'
+    # local lines=($input)
+    local lines=()
+
+    # Read the string into the array, preserving empty lines
+    while IFS= read -r line || [[ -n $line ]]; do
+        lines+=("$line")
+    done <<< "${input}"
+
+    local max_length=0
+
+    # Find the maximum length of a line, accounting for Unicode width
+    for line in "${lines[@]}"; do
+        line_length=$(display_width "$line")
+        if [ $line_length -gt $max_length ]; then
+            max_length=$line_length
+        fi
+    done
+
+    # Ensure the box width is at least the specified minimum width
+    max_length=$(( max_length > min_width ? max_length : min_width ))
+
+    # Top border
+    echo "┌$(printf '─%.0s' $(seq 1 $((max_length + 2))))┐"
+
+    # Print each line with padding
+    for line in "${lines[@]}"; do
+        printf "│ %-${max_length}s │\n" "$line"
+    done
+
+    # Bottom border
+    echo "└$(printf '─%.0s' $(seq 1 $((max_length + 2))))┘"
+}
+
+###################################################################################
+# box_text_attention
+#
+# Description: Like box texty, but output is surrounded by a box;
+# padded with blank lines and attention-getting characters.
+# ##################################################################################
+box_text_attention() {
+    local input
+    local min_width=0
+    local attention=false
+
+    # Parse the optional -w argument
+    while getopts ":w:" opt; do
+        case $opt in
+            w)
+                min_width=$OPTARG
+                ;;
+            \?)
+                echo "Invalid option: -$OPTARG" >&2
+                return 1
+                ;;
+            :)
+                echo "Option -$OPTARG requires an argument." >&2
+                return 1
+                ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+
+    if [ -z "$1" ]; then
+        # Read input from stdin if no arguments are provided
+        input=$(cat)
+    else
+        # Use the provided argument as input
+        input="$1"
+    fi
+
+    local IFS=$'\n'
+    # local lines=($input)
+    local lines=()
+
+    # Read the string into the array, preserving empty lines
+    while IFS= read -r line || [[ -n $line ]]; do
+        lines+=("$line")
+    done <<< "${input}"
+
+    local max_length=0
+
+    # Find the maximum length of a line, accounting for Unicode width
+    for line in "${lines[@]}"; do
+        line_length=$(display_width "$line")
+        if [ $line_length -gt $max_length ]; then
+          max_length=$line_length
+        fi
+    done
+
+    # Ensure the box width is at least the specified minimum width
+    max_length=$(( max_length > min_width ? max_length : min_width ))
+
+    # Top border
+    echo "┌$(printf '─%.0s' $(seq 1 $((max_length + 10))))┐"
+    echo "│ 🔗💠📡$(printf ' %.0s' $(seq 1 $((max_length + 2)))) │"
+
+    # Print each line with padding
+    for line in "${lines[@]}"; do
+        real_length=$(( max_length ))
+        printf "│ 🔗💠📡  %-${real_length}s │\n" "$line"
+    done
+
+    # Bottom border
+    echo "│ 🔗💠📡$(printf ' %.0s' $(seq 1 $((max_length + 2)))) │"
+    echo "└$(printf '─%.0s' $(seq 1 $((max_length + 10))))┘"
+}
+
+###################################################################################
+# ask_and_save
+#
+# Description: Prompt the user with a string, and save the response to the environment file
+#
+# ${1} - env var name to save to the ENV_FILE
+# ${2} - prompt string
+# ${3} - [optional] default response if user hits <Enter>
+# ${4} - [optional] hide input if true (Default: false)
+###################################################################################
+ask_and_save() {
+    local var_name=${1}
+    local prompt=${2}
+    local default_value=${3}
+    local hide_input=${4:-false}
+    local value=
+    local input=
+
+    if [ -z "${default_value}" ]
+    then
+        if [ "${hide_input}" = true ]
+        then
+            read -rsp $'\n'"${prompt} (INPUT HIDDEN): " input
+            echo
+        else
+            read -rp $'\n'"${prompt}: " input
+        fi
+        value=${input}
+    else
+        if [ "${hide_input}" = true ]
+        then
+            read -rsp $'\n'"${prompt} [${default_value}] (INPUT HIDDEN): " input
+            echo
+        else
+            read -rp $'\n'"${prompt} [${default_value}]: " input
+        fi
+        value=${input:-$default_value}
+    fi
+    # Make the variable available in the current shell, useful for subsequent commands
+    export ${var_name}="${value}"
+    echo "${var_name}=\"${value}\"" >> ${ENV_FILE}
+}
+
+###################################################################################
+# redact_sensitive_values
+#
+# Description: Runs a 'sed' command on the input file to replace specific environment
+#              values with "[REDACTED]". Useful for not exposing secrets in live demos.
+#
+###################################################################################
+function redact_sensitive_values() {
+    local env_file="$1"
+    sed \
+        -e 's/^PROVIDER_ACCOUNT_SEED_PHRASE=.*/PROVIDER_ACCOUNT_SEED_PHRASE=[REDACTED]/' \
+        -e 's/^IPFS_BASIC_AUTH_USER=.*/IPFS_BASIC_AUTH_USER=[REDACTED]/' \
+        -e 's/^IPFS_BASIC_AUTH_SECRET=.*/IPFS_BASIC_AUTH_SECRET=[REDACTED]/' \
+        "$env_file"
+}
+
+###################################################################################
+#
+# Description: Save a name/value pair to the environment file & simultaneously
+#              export to the current environment.
+#
+# ${1} - env variable name
+# ${2} - env variable value
+#
+###################################################################################
+function export_save_variable() {
+    local variable_name=$1
+    local value=$2
+
+    echo "${variable_name}=\"${value}\"" >> ${ENV_FILE}
+    export ${variable_name}="${value}"
+}
+
+

--- a/start.sh
+++ b/start.sh
@@ -1,21 +1,31 @@
 #!/bin/bash
+. ./bash_functions.sh
 # Script to start all Gateway services on the Frequency Paseo Testnet
 
 # Function to ask for input with a default value and write to .env-saved
-ask_and_save() {
-    local var_name=${1}
-    local prompt=${2}
-    local default_value=${3}
-    read -rp $'\n'"${prompt} [${default_value}]: " input
-    local value=${input:-$default_value}
-    echo "${var_name}=\"${value}\"" >> .env-saved
-}
+#ask_and_save() {
+#    local var_name=${1}
+#    local prompt=${2}
+#    local default_value=${3}
+#    read -rp $'\n'"${prompt} [${default_value}]: " input
+#    local value=${input:-$default_value}
+#    echo "${var_name}=\"${value}\"" >> .env-saved
+#}
 
 # Check for Docker and Docker Compose
 if ! command -v docker &> /dev/null || ! command -v docker compose &> /dev/null; then
     printf "Docker and Docker Compose are required but not installed. Please install them and try again.\n"
     exit 1
 fi
+
+BASE_DIR=./
+ENV_FILE=${BASE_DIR}/.env-saved
+COMPOSE_PROJECT_NAME=${BASE_NAME}
+
+if [[ -n $ENV_FILE ]]; then
+    echo -e "Using environment file: $ENV_FILE\n"
+fi
+
 
 # Load existing .env-saved file if it exists
 if [ -f .env-saved ]; then
@@ -27,17 +37,9 @@ if [ -f .env-saved ]; then
 
     if [[ ${REUSE_SAVED} =~ ^[Yy] ]]
     then
-        cat << EOI
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Loading existing .env-saved file environment values...                                      ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-EOI
+      box_text -w 96 'Loading existing .env-saved file environment values...'
     else
-        cat << EOI
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Removing previous saved environment...                                                      |
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-EOI
+      box_txt -w 96 'Removing previous saved environment...'
     rm .env-saved
     fi
 fi
@@ -49,32 +51,24 @@ then
     for i in {0..10}
     do
     eval SERVICE_PORT_${i}=$(( STARTING_PORT + i ))
-    eval "export SERVICE_PORT_${i}=\${SERVICE_PORT_${i}}"
-    eval "echo SERVICE_PORT_${i}=\${SERVICE_PORT_${i}}" >> .env-saved
+    export_save_variable SERVICE_PORT_${i} $(( STARTING_PORT + i ))
+#    eval "export SERVICE_PORT_${i}=\${SERVICE_PORT_${i}}"
+#    eval "echo SERVICE_PORT_${i}=\${SERVICE_PORT_${i}}" >> .env-saved
     done
 
     # Create .env-saved file to store environment variables
-    cat << EOI
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Creating .env-saved file to store environment variables...                                  ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
-EOI
+    box_text -w 96 'Creating .env-saved file to store environment variables... '
     echo "COMPOSE_PROJECT_NAME='gateway-dev'" >> .env-saved
     # Ask the user if they want to start on testnet or local
     read -p "Do you want to start on Frequency Paseo Testnet [y/N]: " TESTNET_ENV
-    echo "TESTNET_ENV=\"$TESTNET_ENV\"" >> .env-saved
+    export_save_variable TESTNET_ENV ${TESTNET_ENV}
+#    echo "TESTNET_ENV=\"$TESTNET_ENV\"" >> .env-saved
 
     if [[ $TESTNET_ENV =~ ^[Yy]$ ]]
     then
-    cat << EOI
-
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Setting defaults for testnet...                                                             ┃
-┃ Hit <ENTER> to accept the default value or enter new value and then hit <ENTER>             ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
-EOI
+        box_text -w 96 "Setting defaults for testnet...
+Hit <ENTER> to accept the default value, or,
+enter new value and then hit <ENTER>"
         DEFAULT_TESTNET_ENV="testnet"
         DEFAULT_FREQUENCY_API_WS_URL="wss://0.rpc.testnet.amplica.io"
         DEFAULT_SIWF_NODE_RPC_URL="https://0.rpc.testnet.amplica.io"
@@ -99,32 +93,16 @@ EOI
 
     ask_and_save FREQUENCY_API_WS_URL "Enter the Frequency API Websocket URL" "$DEFAULT_FREQUENCY_API_WS_URL"
     ask_and_save SIWF_NODE_RPC_URL "Enter the SIWF Node RPC URL" "$DEFAULT_SIWF_NODE_RPC_URL"
-cat << EOI
+    box_text_attention -w 88 "A Provider is required to start the services.
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃   🔗💠📡                                                                           📡💠🔗   ┃
-┃   🔗💠📡   A Provider is required to start the services.                           📡💠🔗   ┃
-┃   🔗💠📡                                                                           📡💠🔗   ┃
-┃   🔗💠📡   If you need to become a provider, visit                                 📡💠🔗   ┃
-┃   🔗💠📡   https://provider.frequency.xyz/ to get a Provider ID.                   📡💠🔗   ┃
-┃   🔗💠📡                                                                           📡💠🔗   ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+If you need to become a provider, visit
+https://provider.frequency.xyz/ to get a Provider ID."
 
-EOI
     ask_and_save PROVIDER_ID "Enter Provider ID" "$DEFAULT_PROVIDER_ID"
     ask_and_save PROVIDER_ACCOUNT_SEED_PHRASE "Enter Provider Seed Phrase" "$DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE"
-    cat << EOI
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Do you want to change the IPFS settings [y/N]:                                              ┃
-┃                                                                                             ┃
-┃ Suggestion: Change to an IPFS Pinning Service for better persistence and availability       ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
-EOI
-    read CHANGE_IPFS_SETTINGS
-
-    if [[ $CHANGE_IPFS_SETTINGS =~ ^[Yy]$ ]]
+    box_text -w 88 "Suggestion: Change to an IPFS Pinning Service for better persistence and availability."
+    if yesno "===> Given this suggestion, would you like to change the IPFS settings?"
     then
         ask_and_save IPFS_VOLUME "Enter the IPFS volume" "$DEFAULT_IPFS_VOLUME"
         ask_and_save IPFS_ENDPOINT "Enter the IPFS Endpoint" "$DEFAULT_IPFS_ENDPOINT"
@@ -157,28 +135,24 @@ fi
 echo -e "\nStarting all services..."
 docker compose  --profile webhook --profile backend up -d
 
-cat << EOI
+box_text -w 96 "🚀 You can access the Gateway at the following local addresses: 🚀
+* account-service:
+  - API:              http://localhost:${SERVICE_PORT_3}
+  - Queue management: http://localhost:${SERVICE_PORT_3}/queues
+  - Swagger UI:       http://localhost:${SERVICE_PORT_3}/docs/swagger
 
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ 🚀 You can access the Gateway at the following local addresses: 🚀                          ┃
-┃       * account-service:                                                                    ┃
-┃         - API:              http://localhost:${SERVICE_PORT_3}                                           ┃
-┃         - Queue management: http://localhost:${SERVICE_PORT_3}/queues                                    ┃
-┃         - Swagger UI:       http://localhost:${SERVICE_PORT_3}/docs/swagger                              ┃
-┃                                                                                             ┃
-┃       * content-publishing-service                                                          ┃
-┃         - API:              http://localhost:${SERVICE_PORT_0}                                           ┃
-┃         - Queue management: http://localhost:${SERVICE_PORT_0}/queues                                    ┃
-┃         - Swagger UI:       http://localhost:${SERVICE_PORT_0}/docs/swagger                              ┃
-┃                                                                                             ┃
-┃       * content-watcher-service                                                             ┃
-┃         - API:              http://localhost:${SERVICE_PORT_1}                                           ┃
-┃         - Queue management: http://localhost:${SERVICE_PORT_1}/queues                                    ┃
-┃         - Swagger UI:       http://localhost:${SERVICE_PORT_1}/docs/swagger                              ┃
-┃                                                                                             ┃
-┃       * graph-service                                                                       ┃
-┃         - API:              http://localhost:${SERVICE_PORT_2}                                           ┃
-┃         - Queue management: http://localhost:${SERVICE_PORT_2}/queues                                    ┃
-┃         - Swagger UI:       http://localhost:${SERVICE_PORT_2}/docs/swagger                              ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-EOI
+* content-publishing-service
+  - API:              http://localhost:${SERVICE_PORT_0}
+  - Queue management: http://localhost:${SERVICE_PORT_0}/queues
+  - Swagger UI:       http://localhost:${SERVICE_PORT_0}/docs/swagger
+
+* content-watcher-service
+  - API:              http://localhost:${SERVICE_PORT_1}
+  - Queue management: http://localhost:${SERVICE_PORT_1}/queues
+  - Swagger UI:       http://localhost:${SERVICE_PORT_1}/docs/swagger
+
+* graph-service
+  - API:              http://localhost:${SERVICE_PORT_2}
+  - Queue management: http://localhost:${SERVICE_PORT_2}/queues
+  - Swagger UI:       http://localhost:${SERVICE_PORT_2}/docs/swagger
+"

--- a/start.sh
+++ b/start.sh
@@ -4,32 +4,31 @@
 
 # Check for Docker and Docker Compose
 if ! command -v docker &> /dev/null || ! command -v docker compose &> /dev/null; then
-    echo -e "Docker and Docker Compose are required but not installed. Please install them and try again.\n"
+    ${OUTPUT} "Docker and Docker Compose are required but not installed. Please install them and try again.\n"
     exit 1
 fi
 
 BASE_DIR=./
 ENV_FILE=${BASE_DIR}/.env-saved
 COMPOSE_PROJECT_NAME=${BASE_NAME}
-BOX_WIDTH=96
 
 if [[ -n $ENV_FILE ]]; then
-    echo -e "Using environment file: $ENV_FILE\n"
+    ${OUTPUT} "Using environment file: $ENV_FILE\n"
 fi
 
 
 # Load existing .env-saved file if it exists
 if [ -f .env-saved ]; then
-    echo -e "Found saved environment from a previous run:\n"
+    ${OUTPUT} "Found saved environment from a previous run:\n"
     redact_sensitive_values .env-saved
     echo
-    read -p  "Do you want to re-use the saved paramters? [Y/n]: " REUSE_SAVED
+    read -p  "Do you want to re-use the saved parameters? [Y/n]: " REUSE_SAVED
     REUSE_SAVED=${REUSE_SAVED:-y}
 
     if [[ ${REUSE_SAVED} =~ ^[Yy] ]]; then
-      box_text -w ${BOX_WIDTH} 'Loading existing .env-saved file environment values...'
+      ${OUTPUT} 'Loading existing .env-saved file environment values...'
     else
-      box_text -w ${BOX_WIDTH} 'Removing previous saved environment...'
+      ${OUTPUT} 'Removing previous saved environment...'
     rm .env-saved
     fi
 fi
@@ -44,7 +43,7 @@ if [ ! -f .env-saved ]; then
     done
 
     # Create .env-saved file to store environment variables
-    box_text -w ${BOX_WIDTH} 'Creating .env-saved file to store environment variables... '
+   ${OUTPUT} 'Creating .env-saved file to store environment variables... '
     echo "COMPOSE_PROJECT_NAME='gateway-dev'" >> .env-saved
 
     # Ask the user if they want to start on testnet or local
@@ -80,20 +79,19 @@ EOI
     DEFAULT_IPFS_UA_GATEWAY_URL="http://localhost:8080"
     DEFAULT_CONTENT_DB_VOLUME="content_db"
 
-
     ask_and_save FREQUENCY_API_WS_URL "Enter the Frequency API Websocket URL" "$DEFAULT_FREQUENCY_API_WS_URL"
     ask_and_save SIWF_NODE_RPC_URL "Enter the SIWF Node RPC URL" "$DEFAULT_SIWF_NODE_RPC_URL"
     box_text_attention -w ${BOX_WIDTH} << EOI
 A Provider is required to start the services.
 
 If you need to become a provider, visit
-https://provider.frequency.xyz/ to get a Provider ID."
+https://provider.frequency.xyz/ to get a Provider ID.
 EOI
 
     ask_and_save PROVIDER_ID "Enter Provider ID" "$DEFAULT_PROVIDER_ID"
     ask_and_save PROVIDER_ACCOUNT_SEED_PHRASE "Enter Provider Seed Phrase" "$DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE"
 
-    box_text -w ${BOX_WIDTH} "Suggestion: Change to an IPFS Pinning Service for better persistence and availability."
+   ${OUTPUT} "Suggestion: Change to an IPFS Pinning Service for better persistence and availability."
 
     if yesno "===> Given this suggestion, would you like to change the IPFS settings?";  then
         ask_and_save IPFS_VOLUME "Enter the IPFS volume" "$DEFAULT_IPFS_VOLUME"

--- a/start.sh
+++ b/start.sh
@@ -2,16 +2,6 @@
 . ./bash_functions.sh
 # Script to start all Gateway services on the Frequency Paseo Testnet
 
-# Function to ask for input with a default value and write to .env-saved
-#ask_and_save() {
-#    local var_name=${1}
-#    local prompt=${2}
-#    local default_value=${3}
-#    read -rp $'\n'"${prompt} [${default_value}]: " input
-#    local value=${input:-$default_value}
-#    echo "${var_name}=\"${value}\"" >> .env-saved
-#}
-
 # Check for Docker and Docker Compose
 if ! command -v docker &> /dev/null || ! command -v docker compose &> /dev/null; then
     echo -e "Docker and Docker Compose are required but not installed. Please install them and try again.\n"

--- a/start.sh
+++ b/start.sh
@@ -14,13 +14,14 @@
 
 # Check for Docker and Docker Compose
 if ! command -v docker &> /dev/null || ! command -v docker compose &> /dev/null; then
-    printf "Docker and Docker Compose are required but not installed. Please install them and try again.\n"
+    echo -e "Docker and Docker Compose are required but not installed. Please install them and try again.\n"
     exit 1
 fi
 
 BASE_DIR=./
 ENV_FILE=${BASE_DIR}/.env-saved
 COMPOSE_PROJECT_NAME=${BASE_NAME}
+BOX_WIDTH=96
 
 if [[ -n $ENV_FILE ]]; then
     echo -e "Using environment file: $ENV_FILE\n"
@@ -30,50 +31,48 @@ fi
 # Load existing .env-saved file if it exists
 if [ -f .env-saved ]; then
     echo -e "Found saved environment from a previous run:\n"
-    cat .env-saved
+    redact_sensitive_values .env-saved
     echo
     read -p  "Do you want to re-use the saved paramters? [Y/n]: " REUSE_SAVED
     REUSE_SAVED=${REUSE_SAVED:-y}
 
-    if [[ ${REUSE_SAVED} =~ ^[Yy] ]]
-    then
-      box_text -w 96 'Loading existing .env-saved file environment values...'
+    if [[ ${REUSE_SAVED} =~ ^[Yy] ]]; then
+      box_text -w ${BOX_WIDTH} 'Loading existing .env-saved file environment values...'
     else
-      box_txt -w 96 'Removing previous saved environment...'
+      box_text -w ${BOX_WIDTH} 'Removing previous saved environment...'
     rm .env-saved
     fi
 fi
 
-if [ ! -f .env-saved ]
-then
+if [ ! -f .env-saved ]; then
     # Setup some variables for easy port management
     STARTING_PORT=3010
     for i in {0..10}
     do
     eval SERVICE_PORT_${i}=$(( STARTING_PORT + i ))
     export_save_variable SERVICE_PORT_${i} $(( STARTING_PORT + i ))
-#    eval "export SERVICE_PORT_${i}=\${SERVICE_PORT_${i}}"
-#    eval "echo SERVICE_PORT_${i}=\${SERVICE_PORT_${i}}" >> .env-saved
     done
 
     # Create .env-saved file to store environment variables
-    box_text -w 96 'Creating .env-saved file to store environment variables... '
+    box_text -w ${BOX_WIDTH} 'Creating .env-saved file to store environment variables... '
     echo "COMPOSE_PROJECT_NAME='gateway-dev'" >> .env-saved
+
     # Ask the user if they want to start on testnet or local
     read -p "Do you want to start on Frequency Paseo Testnet [y/N]: " TESTNET_ENV
     export_save_variable TESTNET_ENV ${TESTNET_ENV}
-#    echo "TESTNET_ENV=\"$TESTNET_ENV\"" >> .env-saved
 
-    if [[ $TESTNET_ENV =~ ^[Yy]$ ]]
-    then
-        box_text -w 96 "Setting defaults for testnet...
+    if [[ $TESTNET_ENV =~ ^[Yy]$ ]]; then
+        ${OUTPUT} << EOI
+Setting defaults for testnet...
 Hit <ENTER> to accept the default value, or,
 enter new value and then hit <ENTER>"
+EOI
         DEFAULT_TESTNET_ENV="testnet"
         DEFAULT_FREQUENCY_API_WS_URL="wss://0.rpc.testnet.amplica.io"
         DEFAULT_SIWF_NODE_RPC_URL="https://0.rpc.testnet.amplica.io"
         DEFAULT_PROVIDER_ID="INPUT REQUIRED"
         DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE="INPUT REQUIRED"
+
     else
         echo -e "\nStarting on local..."
         DEFAULT_TESTNET_ENV="local"
@@ -82,6 +81,7 @@ enter new value and then hit <ENTER>"
         DEFAULT_PROVIDER_ID="1"
         DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE="//Alice"
     fi
+
     DEFAULT_IPFS_VOLUME="/data/ipfs"
     DEFAULT_IPFS_ENDPOINT="http://ipfs:5001"
     DEFAULT_IPFS_GATEWAY_URL='https://ipfs.io/ipfs/[CID]'
@@ -93,17 +93,19 @@ enter new value and then hit <ENTER>"
 
     ask_and_save FREQUENCY_API_WS_URL "Enter the Frequency API Websocket URL" "$DEFAULT_FREQUENCY_API_WS_URL"
     ask_and_save SIWF_NODE_RPC_URL "Enter the SIWF Node RPC URL" "$DEFAULT_SIWF_NODE_RPC_URL"
-    box_text_attention -w 88 "A Provider is required to start the services.
+    box_text_attention -w ${BOX_WIDTH} << EOI
+A Provider is required to start the services.
 
 If you need to become a provider, visit
 https://provider.frequency.xyz/ to get a Provider ID."
+EOI
 
     ask_and_save PROVIDER_ID "Enter Provider ID" "$DEFAULT_PROVIDER_ID"
     ask_and_save PROVIDER_ACCOUNT_SEED_PHRASE "Enter Provider Seed Phrase" "$DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE"
 
-    box_text -w 88 "Suggestion: Change to an IPFS Pinning Service for better persistence and availability."
-    if yesno "===> Given this suggestion, would you like to change the IPFS settings?"
-    then
+    box_text -w ${BOX_WIDTH} "Suggestion: Change to an IPFS Pinning Service for better persistence and availability."
+
+    if yesno "===> Given this suggestion, would you like to change the IPFS settings?";  then
         ask_and_save IPFS_VOLUME "Enter the IPFS volume" "$DEFAULT_IPFS_VOLUME"
         ask_and_save IPFS_ENDPOINT "Enter the IPFS Endpoint" "$DEFAULT_IPFS_ENDPOINT"
         ask_and_save IPFS_GATEWAY_URL "Enter the IPFS Gateway URL" "$DEFAULT_IPFS_GATEWAY_URL"
@@ -121,11 +123,12 @@ IPFS_BASIC_AUTH_SECRET="${DEFAULT_IPFS_BASIC_AUTH_SECRET}"
 IPFS_UA_GATEWAY_URL="${DEFAULT_IPFS_UA_GATEWAY_URL}"
 EOI
     fi
+
 fi
+
 set -a; source .env-saved; set +a
 
-if [[ ! $TESTNET_ENV =~ ^[Yy]$ ]]
-then
+if [[ ! $TESTNET_ENV =~ ^[Yy]$ ]]; then
     # Start specific services in detached mode
     echo -e "\nStarting local frequency services..."
     docker compose up -d frequency
@@ -135,7 +138,8 @@ fi
 echo -e "\nStarting all services..."
 docker compose  --profile webhook --profile backend up -d
 
-box_text -w 96 "🚀 You can access the Gateway at the following local addresses: 🚀
+box_text_attention -w ${BOX_WIDTH} <<EOI
+You can access the Gateway at the following local addresses:
 * account-service:
   - API:              http://localhost:${SERVICE_PORT_3}
   - Queue management: http://localhost:${SERVICE_PORT_3}/queues
@@ -155,4 +159,4 @@ box_text -w 96 "🚀 You can access the Gateway at the following local addresses
   - API:              http://localhost:${SERVICE_PORT_2}
   - Queue management: http://localhost:${SERVICE_PORT_2}/queues
   - Swagger UI:       http://localhost:${SERVICE_PORT_2}/docs/swagger
-"
+EOI

--- a/stop.sh
+++ b/stop.sh
@@ -10,7 +10,7 @@ if [ -f .env-saved ]; then
 fi
 
 # Shutting down any running services
-echo "Shutting down any running services..."
+${OUTPUT} "Shutting down any running services..."
 docker compose --profile local-node --profile backend --profile frontend --profile webhook down
 
 # Ask the user if they want to remove specified volumes
@@ -33,5 +33,5 @@ then
         docker volume rm ${COMPOSE_PROJECT_NAME}_chainstorage
     fi
 else
-    echo "Leaving Docker volumes alone."
+    ${OUTPUT} "Leaving Docker volumes alone."
 fi

--- a/stop.sh
+++ b/stop.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+. ./bash_functions.sh
+
 # Stop all services and optionally remove specified volumes to remove all state and start fresh
 
 # Export the variables that are used in the docker-compose.yaml file
@@ -11,9 +14,7 @@ echo "Shutting down any running services..."
 docker compose --profile local-node --profile backend --profile frontend --profile webhook down
 
 # Ask the user if they want to remove specified volumes
-read -p "Do you want to remove specified volumes to remove all state and start fresh? [y/N]: " REMOVE_VOLUMES
-
-if [[ $REMOVE_VOLUMES =~ ^[Yy]$ ]]
+if yesno "Do you want to remove specified volumes to remove all state and start fresh" N
 then
     echo "Removing specified volumes..."
     # Docker volume names are lowercase versions of the directory name


### PR DESCRIPTION
## Goal
The goal of this PR is to update the start and stop scripts to use bash_functions.sh imported from Social App Template.   Some of the output has been altered to make the width work out when using special characters.

- [x] functionally complete
- [x] refactoring + tidy
- [x] self review + comments

Closes #456 

## Steps to Verify:
1. Do set up required for starting services (e.g. Docker daemon)
1. Uninstall PCRE-grep if you have it (possibly with brew)
1. check out and run the start script, entering default values.
  ```shell
  git co chore/refactor-start-stop-#456
  rm .env-saved # optional
  ./start
  ```
4. Go through all the questions, make sure there are no problems with the console output, that it's nice and tidy.
5. Verify that the .env-saved file has correct output
6. Then run the stop script and ensure that it does stop the docker containers.
7. Install a PCRE-compatible script and repeat the above, ensuring that the output is formatted well.
8. Also verify that the previous environment variables are redacted when it's a secret or seed