### PR TITLE
fix: make sure correct tag is used when release workflow is triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           test_run=false
           ENTIRE_TAG_RE="^(([[:alpha:]\-]+)-)?(.*)$"
           VERSION_TAG_RE="^v[\.]?([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alpha:][:digit:]\.]+)*)$"
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${FULL_TAG}"
           echo "Running with tag: ${TAG}"
           if [[ "$TAG" =~ ${ENTIRE_TAG_RE} ]] ; then
             SERVICE=${BASH_REMATCH[2]}


### PR DESCRIPTION
This PR fixes an issue where the release workflow processes a blank tag when triggered manually instead of from a release event.