### PR TITLE
fix: do not update DockerHub image description for test runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
           tags: ${{ steps.cp-tags.outputs.tags }}
       - name: Update DockerHub Description
         uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae
+        if: needs.set_variables.outputs.test_run != 'true'
         with:
           username: ${{secrets.DOCKERHUB_USERNAME}}
           password: ${{secrets.DOCKERHUB_TOKEN}}


### PR DESCRIPTION
This PR skips updating the DockerHub image description if the release flow is running as a test run.