### PR TITLE
feat: add handle validation using blockchain service in HandlesControllerV1 and AccountsControllerV2

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -70,13 +70,12 @@ jobs:
           echo "CHANGES=${{ needs.service-matrix.outputs.changes }}"
           echo "SERVICES=${{ needs.service-matrix.outputs.services }}"
           echo "RUN-ALL=${{ needs.service-matrix.outputs.run-all }}"
-          echo "ACCOUNT_CHANGE_DETECTED=${{ contains(fromJson(needs.service-matrix.outputs.changes), 'account') }}"
+          echo "ACCOUNT_CHANGE_DETECTED=${{ contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}"
 
       - name: Run or Skip
         id: should
         run: |
-          echo "MATRIX_SERVICE=${{ matrix.service }}"
-          echo "RUN=${{contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
+          echo "RUN=${{ needs.service-matrix.outputs.run-all || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: ${{ steps.should.outputs.RUN == 'true' }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -53,6 +53,8 @@ jobs:
               - 'apps/content-watcher/**'
               - 'libs/content-watcher-lib/**'
               - 'libs/storage/**'
+      - name: Debug determine-matrix changes output
+        run: echo 'CHANGES=${{ steps.determine-matrix.outputs.changes }}'
 
   build:
     name: '[${{ matrix.service }}] E2E Tests'
@@ -63,6 +65,13 @@ jobs:
       matrix:
         service: ${{ fromJson(needs.service-matrix.outputs.services) }}
     steps:
+      - name: Debug Run or Skip Errors
+        run: |
+          echo "CHANGES=${{ needs.service-matrix.outputs.changes }}"
+          echo "SERVICES=${{ needs.service-matrix.outputs.services }}"
+          echo "RUN-ALL=${{ needs.service-matrix.outputs.run-all }}"
+          echo "ACCOUNT_CHANGE_DETECTED=${{ contains(fromJson(needs.service-matrix.outputs.changes), 'account') }}"
+
       - name: Run or Skip
         id: should
         run: echo "RUN=${{ needs.service-matrix.outputs.run-all || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -74,7 +74,9 @@ jobs:
 
       - name: Run or Skip
         id: should
-        run: echo "RUN=${{ needs.service-matrix.outputs.run-all || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "MATRIX_SERVICE=${{ matrix.service }}"
+          echo "RUN=${{contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: ${{ steps.should.outputs.RUN == 'true' }}

--- a/apps/account-api/src/controllers/v1/handles-v1.controller.ts
+++ b/apps/account-api/src/controllers/v1/handles-v1.controller.ts
@@ -11,7 +11,7 @@ import {
   BadRequestException,
   NotFoundException,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { HandlesService } from '#account-api/services/handles.service';
 import { EnqueueService } from '#account-lib/services/enqueue-request.service';
 import {
@@ -26,6 +26,7 @@ import { ReadOnlyGuard } from '#account-api/guards/read-only.guard';
 import { u8aToHex } from '@polkadot/util';
 import { TransactionType } from '#types/account-webhook';
 import { HandleDto, MsaIdDto } from '#types/dtos/common';
+import { BlockchainRpcQueryService } from '#blockchain/blockchain-rpc-query.service';
 
 @Controller({ version: '1', path: 'handles' })
 @ApiTags('v1/handles')
@@ -36,14 +37,31 @@ export class HandlesControllerV1 {
   constructor(
     private handlesService: HandlesService,
     private enqueueService: EnqueueService,
+    private blockchainService: BlockchainRpcQueryService,
   ) {
     this.logger = new Logger(this.constructor.name);
+  }
+
+  /**
+   * Validates the provided handle by checking its validity using the blockchain service.
+   * If the handle is not valid, a BadRequestException is thrown.
+   *
+   * @param baseHandle - The handle to be validated.
+   * @throws {BadRequestException} If the handle is invalid.
+   * @returns {Promise<void>} A promise that resolves if the handle is valid.
+   */
+  async validateHandle(baseHandle: string): Promise<void> {
+    const isValidHandle = await this.blockchainService.isValidHandle(baseHandle);
+    if (isValidHandle.isFalse) {
+      throw new BadRequestException('Invalid handle provided!');
+    }
   }
 
   @Post()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Request to create a new handle for an account' })
   @ApiOkResponse({ description: 'Handle creation request enqueued', type: TransactionResponse })
+  @ApiBadRequestResponse({ description: 'Invalid handle provided or Provided signature is not valid for the payload!' })
   /**
    * Creates a handle using the provided query parameters.
    * @param queryParams - The query parameters for creating the account.
@@ -51,6 +69,7 @@ export class HandlesControllerV1 {
    * @throws An error if the handle creation fails.
    */
   async createHandle(@Body() createHandleRequest: HandleRequestDto): Promise<TransactionResponse> {
+    await this.validateHandle(createHandleRequest.payload.baseHandle);
     if (!this.handlesService.verifyHandleRequestSignature(createHandleRequest)) {
       throw new BadRequestException('Provided signature is not valid for the payload!');
     }
@@ -66,6 +85,7 @@ export class HandlesControllerV1 {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Request to change a handle' })
   @ApiOkResponse({ description: 'Handle change request enqueued', type: TransactionResponse })
+  @ApiBadRequestResponse({ description: 'Invalid handle provided or Provided signature is not valid for the payload!' })
   /**
    * Using the provided query parameters, removes the old handle and creates a new one.
    * @param queryParams - The query parameters for changing the handle.
@@ -73,6 +93,7 @@ export class HandlesControllerV1 {
    * @throws An error if the handle creation fails.
    */
   async changeHandle(@Body() changeHandleRequest: HandleRequestDto): Promise<TransactionResponse> {
+    await this.validateHandle(changeHandleRequest.payload.baseHandle);
     if (!this.handlesService.verifyHandleRequestSignature(changeHandleRequest)) {
       throw new BadRequestException('Provided signature is not valid for the payload!');
     }
@@ -91,6 +112,7 @@ export class HandlesControllerV1 {
     description: 'Returned an encoded ClaimHandlePayload for signing',
     type: ChangeHandlePayloadRequest,
   })
+  @ApiBadRequestResponse({ description: 'Invalid handle provided' })
   /**
    * Using the provided query parameters, creates a new payload that can be signed to change handle.
    * @param queryParams - The query parameters for changing the handle.
@@ -99,6 +121,7 @@ export class HandlesControllerV1 {
    */
   async getChangeHandlePayload(@Param() { newHandle }: HandleDto): Promise<ChangeHandlePayloadRequest> {
     const expiration = await this.handlesService.getExpiration();
+    await this.validateHandle(newHandle);
     const payload = { baseHandle: newHandle, expiration };
     const encodedPayload = u8aToHex(this.handlesService.encodePayload(payload).toU8a());
 

--- a/apps/account-api/src/controllers/v2/accounts-v2.controller.ts
+++ b/apps/account-api/src/controllers/v2/accounts-v2.controller.ts
@@ -101,12 +101,14 @@ export class AccountsControllerV2 {
 
     // Validate claim handle transactions to prevent invalid submissions to the blockchain
     await Promise.all(
-      payload.payloads.filter(isPayloadClaimHandle).map(async (claimHandle) => {
-        const isValidHandle = await this.blockchainService.isValidHandle(claimHandle.payload.baseHandle);
-        if (isValidHandle.isFalse) {
-          throw new BadRequestException('Invalid base handle');
-        }
-      }),
+      payload.payloads
+        .filter((transaction) => isPayloadClaimHandle(transaction))
+        .map(async (claimHandle) => {
+          const isValidHandle = await this.blockchainService.isValidHandle(claimHandle.payload.baseHandle);
+          if (isValidHandle.isFalse) {
+            throw new BadRequestException('Invalid base handle');
+          }
+        }),
     );
 
     if (hasChainSubmissions(payload) && this.chainConfig.isDeployedReadOnly) {

--- a/apps/account-api/test/handles.controller.e2e-spec.ts
+++ b/apps/account-api/test/handles.controller.e2e-spec.ts
@@ -169,5 +169,13 @@ describe('Handles Controller', () => {
         .expect(HttpStatus.NOT_FOUND)
         .expect((res) => expect(res.text).toContain('Invalid msaId'));
     });
+
+    it('(GET) /handles/change/:newHandle with invalid handle', async () => {
+      const invalidHandle = 'invalidHandle';
+      await request(HTTP_SERVER)
+        .get(`/v1/handles/change/${invalidHandle}`)
+        .expect(HttpStatus.BAD_REQUEST)
+        .expect((res) => expect(res.text).toContain('Invalid handle provided'));
+    });
   });
 });

--- a/apps/account-api/test/handles.controller.e2e-spec.ts
+++ b/apps/account-api/test/handles.controller.e2e-spec.ts
@@ -171,7 +171,7 @@ describe('Handles Controller', () => {
     });
 
     it('(GET) /handles/change/:newHandle with invalid handle', async () => {
-      const invalidHandle = 'invalidHandle';
+      const invalidHandle = 'ThisHandleIsTooLongForFrequency';
       await request(HTTP_SERVER)
         .get(`/v1/handles/change/${invalidHandle}`)
         .expect(HttpStatus.BAD_REQUEST)

--- a/libs/account-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/account-lib/src/utils/blockchain-scanner.service.ts
@@ -89,7 +89,6 @@ export abstract class BlockchainScannerService {
         this.scanInProgress = false;
         return;
       }
-      // this.logger.verbose(`Starting scan from block #${currentBlockNumber}`);
 
       // eslint-disable-next-line no-constant-condition
       while (!this.paused) {
@@ -113,7 +112,6 @@ export abstract class BlockchainScannerService {
       }
     } catch (e) {
       if (e instanceof EndOfChainError) {
-        // this.logger.debug(e.message);
         return;
       }
 

--- a/libs/account-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/account-lib/src/utils/blockchain-scanner.service.ts
@@ -89,7 +89,7 @@ export abstract class BlockchainScannerService {
         this.scanInProgress = false;
         return;
       }
-      this.logger.verbose(`Starting scan from block #${currentBlockNumber}`);
+      // this.logger.verbose(`Starting scan from block #${currentBlockNumber}`);
 
       // eslint-disable-next-line no-constant-condition
       while (!this.paused) {
@@ -113,7 +113,7 @@ export abstract class BlockchainScannerService {
       }
     } catch (e) {
       if (e instanceof EndOfChainError) {
-        this.logger.debug(e.message);
+        // this.logger.debug(e.message);
         return;
       }
 

--- a/libs/blockchain/src/blockchain-rpc-query.service.ts
+++ b/libs/blockchain/src/blockchain-rpc-query.service.ts
@@ -4,7 +4,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { AccountId, AccountId32, BlockHash, BlockNumber, Event, SignedBlock } from '@polkadot/types/interfaces';
 import { ApiDecoration, SubmittableExtrinsic } from '@polkadot/api/types';
 import { AnyNumber, Codec, DetectCodec, ISubmittableResult, SignerPayloadRaw } from '@polkadot/types/types';
-import { Bytes, Option, u128, u16, Vec } from '@polkadot/types';
+import { bool, Bytes, Option, u128, u16, Vec } from '@polkadot/types';
 import {
   CommonPrimitivesMsaDelegation,
   CommonPrimitivesMsaProviderRegistryEntry,
@@ -144,6 +144,16 @@ export class BlockchainRpcQueryService extends PolkadotApiService {
 
     this.logger.error(`No block found corresponding to hash ${hash}`);
     return undefined;
+  }
+
+  /**
+   * Validates a given handle by querying the blockchain.
+   *
+   * @param {string} baseHandle - The base handle to be validated.
+   * @returns {Promise<bool>} - A promise that resolves to a bool indicating whether the handle is valid.
+   */
+  public async isValidHandle(baseHandle: string): Promise<bool> {
+    return this.api.rpc.handles.validateHandle(baseHandle);
   }
 
   public async getNonce(account: string | Uint8Array | AccountId): Promise<number> {


### PR DESCRIPTION
# Problem
When working with handles, new handles should be validated before sending transactions to the blockchain.

Closes #676 

# Solution

Implemented `isValidHandle()` which uses `validateHandle()` RPC to validate base handles before sending them to the blockchain.

## Steps to Verify:

1. Setup Account Service.
2. Use Swagger to test `/v1/handles/change/{newHandle}` a base handle that is longer than 20 characters and verify that the response is 400.
3. Use example.mjs to use SIWF v2 and choose a handle that is too long and observe the 400 response.

![Screenshot 2024-11-05 at 10 19 05](https://github.com/user-attachments/assets/c54684b7-0d9b-478e-be11-e64baecacec8)

