### PR TITLE
fix: use correct test for determine if jobs should run for matrix items

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Run or Skip
         id: should
-        run: echo "RUN=${{ needs.service-matrix.outputs.run-all || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
+        run: echo "RUN=${{ needs.service-matrix.outputs.run-all == true || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: ${{ steps.should.outputs.RUN == 'true' }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
+
       - uses: dorny/paths-filter@v3
         id: determine-matrix
         with:
@@ -53,8 +54,6 @@ jobs:
               - 'apps/content-watcher/**'
               - 'libs/content-watcher-lib/**'
               - 'libs/storage/**'
-      - name: Debug determine-matrix changes output
-        run: echo 'CHANGES=${{ steps.determine-matrix.outputs.changes }}'
 
   build:
     name: '[${{ matrix.service }}] E2E Tests'
@@ -65,17 +64,9 @@ jobs:
       matrix:
         service: ${{ fromJson(needs.service-matrix.outputs.services) }}
     steps:
-      - name: Debug Run or Skip Errors
-        run: |
-          echo "CHANGES=${{ needs.service-matrix.outputs.changes }}"
-          echo "SERVICES=${{ needs.service-matrix.outputs.services }}"
-          echo "RUN-ALL=${{ needs.service-matrix.outputs.run-all }}"
-          echo "ACCOUNT_CHANGE_DETECTED=${{ contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}"
-
       - name: Run or Skip
         id: should
-        run: |
-          echo "RUN=${{ needs.service-matrix.outputs.run-all || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
+        run: echo "RUN=${{ needs.service-matrix.outputs.run-all == true || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: ${{ steps.should.outputs.RUN == 'true' }}

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -17,7 +17,7 @@ jobs:
       services: >-
         ["account-api", "graph-api", "content-publishing-api", "content-watcher"]
       # Resolves to true if it should run everything, aka when common files change
-      run-all: ${{ steps.determine-matrix.outputs.changes.common }}
+      run-all: ${{ contains(fromJson(steps.determine-matrix.outputs.changes), 'common') }}
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Run or Skip
         id: should
-        run: echo "RUN=${{ needs.service-matrix.outputs.run-all || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
+        run: echo "RUN=${{ needs.service-matrix.outputs.run-all == true || contains(fromJson(needs.service-matrix.outputs.changes), matrix.service) }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: ${{ steps.should.outputs.RUN == 'true' }}


### PR DESCRIPTION
# Problem
Correct suite of matrix CI jobs were not being run based on files included in a PR

# Solution
Use correct logic in the pipeline variable output. Boolean variables cannot be tested alone, apparently, but must be part of a comparison in order to generate a boolean result.

ie,
```yaml
${{ some-var || some-function-call() }}
```
doesn't work, because `some-var` is evaluated as a string. Replace with:
```yaml
# Note, can use true or "true" here, as YAML coerces to a string
${{ some-var == true | | some-function-call() }}
```

Tested locally with (https://github.com/nektos/act)[https://github.com/nektos/act]