### PR TITLE
update docs to correct dependencies on IPFS

### DIFF
--- a/deployment/swarm/docker-compose-swarm.yaml
+++ b/deployment/swarm/docker-compose-swarm.yaml
@@ -134,7 +134,6 @@ services:
       START_PROCESS: graph-api
     depends_on:
       - redis
-      - ipfs
     networks:
       - gateway-net
 
@@ -148,7 +147,6 @@ services:
       START_PROCESS: graph-worker
     depends_on:
       - redis
-      - ipfs
     networks:
       - gateway-net
 

--- a/docker-compose-k6.account-api.yaml
+++ b/docker-compose-k6.account-api.yaml
@@ -13,8 +13,6 @@ services:
     depends_on: !override
       redis:
         condition: service_started
-      ipfs:
-        condition: service_healthy
       account-service-webhook:
         condition: service_healthy
     environment:
@@ -29,7 +27,6 @@ services:
     volumes: !reset []
     depends_on: !override
       - redis
-      - ipfs
     environment:
       WEBHOOK_BASE_URL: 'http://account-service-webhook:3001/webhooks/account-service'
 

--- a/docs/src/Run/README.md
+++ b/docs/src/Run/README.md
@@ -72,7 +72,7 @@ See the [docker-compose-swarm.yaml](https://github.com/projectlibertylabs/gatewa
 | **Graph Service**              | **Details**                                                                                       |
 |--------------------------------|---------------------------------------------------------------------------------------------------|
 | **Docker Image**               | `projectlibertylabs/graph-service`                                                                |
-| **Dependencies**               | Redis, IPFS                                                                                       |
+| **Dependencies**               | Redis                                                                                       |
 | **API Ports**                  | `3000`                                                                                            |
 | **Inter-Service Ports**        | `6379, 9944`                                                                                      |
 | **Docker Compose Services**    | graph-service-api `START_PROCESS: graph-api`                                                      |


### PR DESCRIPTION
This PR updates relevant docs to correct the stated dependency on IPFS. The Account and Graph services are not dependent on IPFS, while content services are.
