### PR TITLE
remove CHAIN_ENVIRONMENT env var

### DIFF
--- a/deployment/swarm/docker-compose-swarm.yaml
+++ b/deployment/swarm/docker-compose-swarm.yaml
@@ -17,7 +17,6 @@ x-common-environment: &common-environment
   IPFS_BASIC_AUTH_USER: ${IPFS_BASIC_AUTH_USER:-""}
   IPFS_BASIC_AUTH_SECRET: ${IPFS_BASIC_AUTH_SECRET:-""}
   QUEUE_HIGH_WATER: 1000
-  CHAIN_ENVIRONMENT: 'dev'
   DEBUG: 'true'
 
 x-content-publishing-env: &content-publishing-env

--- a/docker-compose-e2e.account.yaml
+++ b/docker-compose-e2e.account.yaml
@@ -17,7 +17,6 @@ x-common-environment: &common-environment
   IPFS_BASIC_AUTH_USER: ${IPFS_BASIC_AUTH_USER:-""}
   IPFS_BASIC_AUTH_SECRET: ${IPFS_BASIC_AUTH_SECRET:-""}
   QUEUE_HIGH_WATER: 1000
-  CHAIN_ENVIRONMENT: dev
   DEBUG: true
 
 x-account-service-env: &account-service-env

--- a/docker-compose-published.yaml
+++ b/docker-compose-published.yaml
@@ -17,7 +17,6 @@ x-common-environment: &common-environment
   IPFS_BASIC_AUTH_USER: ${IPFS_BASIC_AUTH_USER:-""}
   IPFS_BASIC_AUTH_SECRET: ${IPFS_BASIC_AUTH_SECRET:-""}
   QUEUE_HIGH_WATER: 1000
-  CHAIN_ENVIRONMENT: dev
   DEBUG: true
 
 x-content-publishing-env: &content-publishing-env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,6 @@ x-common-environment: &common-environment
   IPFS_BASIC_AUTH_USER: ${IPFS_BASIC_AUTH_USER:-""}
   IPFS_BASIC_AUTH_SECRET: ${IPFS_BASIC_AUTH_SECRET:-""}
   QUEUE_HIGH_WATER: 1000
-  CHAIN_ENVIRONMENT: dev
   DEBUG: true
 
 x-content-publishing-env: &content-publishing-env

--- a/docs/src/Run/README.md
+++ b/docs/src/Run/README.md
@@ -38,7 +38,6 @@ The following environment variables are common to all Gateway Services. This sni
   IPFS_BASIC_AUTH_USER: ${IPFS_BASIC_AUTH_USER:-""}
   IPFS_BASIC_AUTH_SECRET: ${IPFS_BASIC_AUTH_SECRET:-""}
   QUEUE_HIGH_WATER: 1000
-  CHAIN_ENVIRONMENT: 'dev'
 ```
 
 Each service requires connection to a Redis instance. The `REDIS_URL` environment variable is set to `redis://redis:6379` by default. If you are using a different Redis instance, you can set the `REDIS_URL` environment variable to the appropriate connection string.


### PR DESCRIPTION
The goal of this PR is to remove `CHAIN_ENVIRONMENT` var from repo as it appears not being used anymore.