### PR TITLE
fix: revert DSNP content hash validation changes, update tests

### DIFF
--- a/apps/content-publishing-api/k6-test/helpers.js
+++ b/apps/content-publishing-api/k6-test/helpers.js
@@ -2,8 +2,9 @@ import { validContentNoUploadedAssets } from '../test/mockRequestData.ts';
 import { b64encode } from 'k6/encoding';
 import http from 'k6/http';
 import { check } from 'k6';
+import { randomBytes } from 'k6/crypto';
 
-export const mockAsset = (size) => {
+export const mockAsset = (size, extension = 'jpg', mimetype = 'image/jpeg') => {
   let fileSize;
   switch (size) {
     case 'sm':
@@ -16,16 +17,15 @@ export const mockAsset = (size) => {
       fileSize = 50 * 1000 * 1000; // 50MB
       break;
   }
-  const char = 'g';
-  const str = char.repeat(fileSize);
-  const buffer = b64encode(str, 'utf-8');
+  const arrayBuf = randomBytes(fileSize);
+  const buffer = b64encode(arrayBuf, 'utf-8');
   return {
-    files: http.file(buffer, 'file1.jpg', 'image/jpeg'),
+    files: http.file(buffer, `file1.${extension}`, mimetype),
   };
 };
 
-export const getReferenceId = (baseUrl) => {
-  const asset = mockAsset('sm');
+export const getReferenceId = (baseUrl, extension = 'jpg', mimetype = 'image/jpeg') => {
+  const asset = mockAsset('sm', extension, mimetype);
   // Send the PUT request
   const assetRequest = http.put(baseUrl + `/v1/asset/upload`, asset);
   let referenceId = '';
@@ -35,12 +35,12 @@ export const getReferenceId = (baseUrl) => {
   return referenceId;
 };
 
-export const createContentWithAsset = (baseUrl) => {
-  const referenceId = getReferenceId(baseUrl);
+export const createContentWithAsset = (baseUrl, extension = 'jpg', mimetype = 'image/jpeg') => {
+  const referenceId = getReferenceId(baseUrl, extension, mimetype);
   return Object.assign({}, validContentNoUploadedAssets, {
     assets: [
       {
-        name: 'file1.jpg',
+        name: `file1.${extension}`,
         references: [
           {
             referenceId: referenceId,

--- a/apps/content-publishing-api/k6-test/script.k6.js
+++ b/apps/content-publishing-api/k6-test/script.k6.js
@@ -18,6 +18,7 @@ import {
   validProfileNoUploadedAssets,
   validReaction,
   validReplyNoUploadedAssets,
+  validOnChainContent,
 } from '../test/mockRequestData.ts';
 
 import { getReferenceId, createContentWithAsset } from './helpers.js';
@@ -43,7 +44,7 @@ export default function () {
     {
       let url = BASE_URL + `/v1/content/${msaId}`;
       const body = {
-        targetContentHash: 'bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy',
+        targetContentHash: 'bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna',
         targetAnnouncementType: 'broadcast',
         content: validContentNoUploadedAssets,
       };
@@ -58,7 +59,7 @@ export default function () {
     {
       let url = BASE_URL + `/v1/content/${msaId}`;
       const body = {
-        targetContentHash: 'bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy',
+        targetContentHash: 'bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna',
         targetAnnouncementType: 'broadcast',
         content: createContentWithAsset(BASE_URL),
       };
@@ -74,7 +75,7 @@ export default function () {
     {
       let url = BASE_URL + `/v1/content/${msaId}`;
       let body = {
-        targetContentHash: 'bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy',
+        targetContentHash: 'bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna',
         targetAnnouncementType: 'broadcast',
       };
       let params = { headers: { 'Content-Type': 'application/json', Accept: 'application/json' } };
@@ -201,6 +202,37 @@ export default function () {
     {
       let url = BASE_URL + `/v1/content/${msaId}/reply`;
       let body = Object.assign({}, validReplyNoUploadedAssets, { content: createContentWithAsset(BASE_URL) });
+      let params = { headers: { 'Content-Type': 'application/json', Accept: 'application/json' } };
+      let request = http.post(url, JSON.stringify(body), params);
+
+      check(request, {
+        '': (r) => r.status === 202,
+      });
+    }
+  });
+
+  group('/v2/content/{msaId}/on-chain', () => {
+    let msaId = '1';
+
+    // Request: ContentControllerV2_postContent
+    {
+      let url = BASE_URL + `/v2/content/${msaId}/on-chain`;
+      let body = validOnChainContent;
+      let params = { headers: { 'Content-Type': 'application/json', Accept: 'application/json' } };
+      let request = http.post(url, JSON.stringify(body), params);
+
+      check(request, {
+        '': (r) => r.status === 202,
+      });
+    }
+  });
+
+  group('/v2/content/batchAnnouncement', () => {
+    // Request No. 2: ContentControllerV2_batchAnnouncement with asset
+    {
+      let url = BASE_URL + `/v2/content/batchAnnouncement`;
+      const referenceId = getReferenceId(BASE_URL, 'parquet', 'application/vnd.apache.parquet');
+      let body = { batchFiles: [{ cid: referenceId, schemaId: 16001 }] };
       let params = { headers: { 'Content-Type': 'application/json', Accept: 'application/json' } };
       let request = http.post(url, JSON.stringify(body), params);
 

--- a/apps/content-publishing-api/k6-test/script_lg_files.js
+++ b/apps/content-publishing-api/k6-test/script_lg_files.js
@@ -17,7 +17,7 @@ export const options = {
 };
 
 export default function () {
-  group('/v1/asset/upload medium files', () => {
+  group('/v1/asset/upload large files', () => {
     let url = BASE_URL + `/v1/asset/upload`;
     // Request No. 1: ApiController_assetUpload large files
     {

--- a/apps/content-publishing-api/src/api.service.ts
+++ b/apps/content-publishing-api/src/api.service.ts
@@ -122,9 +122,7 @@ export class ApiService {
         ),
       );
     } else if (content.batchFiles) {
-      content.batchFiles.forEach((batchFile) =>
-        checkingList.push({ onlyImage: false, referenceId: batchFile.referenceId }),
-      );
+      content.batchFiles.forEach((batchFile) => checkingList.push({ onlyImage: false, referenceId: batchFile.cid }));
     }
 
     const redisResults = await Promise.all(

--- a/apps/content-publishing-api/test/mockRequestData.ts
+++ b/apps/content-publishing-api/test/mockRequestData.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { randomString } from 'https://jslib.k6.io/k6-utils/1.6.0/index.js';
+
 export const validLocation = {
   name: 'name of location',
   accuracy: 97,
@@ -40,13 +43,13 @@ export const validBroadCastNoUploadedAssets = {
 
 export const validReplyNoUploadedAssets = {
   content: validContentNoUploadedAssets,
-  inReplyTo: 'dsnp://78187493520/bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy',
+  inReplyTo: 'dsnp://78187493520/bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna',
 };
 
 export const validReaction = {
   emoji: '🤌🏼',
   apply: 5,
-  inReplyTo: 'dsnp://78187493520/bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy',
+  inReplyTo: 'dsnp://78187493520/bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna',
 };
 
 export const validProfileNoUploadedAssets = {
@@ -55,4 +58,10 @@ export const validProfileNoUploadedAssets = {
   name: 'name of profile content',
   tag: validTags,
   location: validLocation,
+};
+
+export const validOnChainContent = {
+  schemaId: 16001,
+  payload: `0x${randomString(1024, '0123456789abcdef')}`,
+  published: new Date().toISOString(),
 };

--- a/apps/content-publishing-worker/src/batch_announcer/batch.announcer.ts
+++ b/apps/content-publishing-worker/src/batch_announcer/batch.announcer.ts
@@ -71,10 +71,10 @@ export class BatchAnnouncer {
 
   public async announceExistingBatch(batch: IBatchFile): Promise<IPublisherJob> {
     // Get previously uploaded file from IPFS
-    const { Key: cid, Size: size } = await this.ipfsService.getInfo(batch.referenceId);
+    const { Key: cid, Size: size } = await this.ipfsService.getInfo(batch.cid);
 
     const ipfsUrl = await this.formIpfsUrl(cid);
-    const response = { id: batch.referenceId, schemaId: batch.schemaId, data: { cid, payloadLength: size } };
+    const response = { id: batch.cid, schemaId: batch.schemaId, data: { cid, payloadLength: size } };
     this.logger.debug(`Created job to announce existing batch: ${JSON.stringify(response)}`);
     this.logger.debug(`IPFS URL: ${ipfsUrl}`);
     return response;

--- a/libs/types/src/dtos/content-publishing/announcement.dto.ts
+++ b/libs/types/src/dtos/content-publishing/announcement.dto.ts
@@ -12,6 +12,7 @@ import { IsIntValue } from '#utils/decorators/is-int-value.decorator';
 import { ApiProperty } from '@nestjs/swagger';
 import { IBatchFile, IBroadcast, IProfile, IReaction, IReply, ITombstone, IUpdate } from '#types/interfaces';
 import { IsSchemaId } from '#utils/decorators/is-schema-id.decorator';
+import { IsCidV1 } from '#utils/decorators/is-cidv1.decorator';
 
 // eslint-disable-next-line no-shadow
 export enum ModifiableAnnouncementType {
@@ -29,7 +30,7 @@ export class BroadcastDto implements IBroadcast {
 export class ReplyDto implements IReply {
   /**
    * Target DSNP Content URI
-   * @example 'dsnp://78187493520/bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy'
+   * @example 'dsnp://78187493520/bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna'
    */
   @IsDsnpContentURI()
   inReplyTo: string;
@@ -43,7 +44,7 @@ export class ReplyDto implements IReply {
 export class TombstoneDto implements ITombstone {
   /**
    * Target DSNP Content Hash
-   * @example 'bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy'
+   * @example 'bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna'
    */
   @IsDsnpContentHash()
   @IsNotEmpty()
@@ -62,7 +63,7 @@ export class TombstoneDto implements ITombstone {
 export class UpdateDto implements IUpdate {
   /**
    * Target DSNP Content Hash
-   * @example 'bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy'
+   * @example 'bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna'
    */
   @IsDsnpContentHash()
   @IsNotEmpty()
@@ -102,7 +103,7 @@ export class ReactionDto implements IReaction {
 
   /**
    * Target DSNP Content URI
-   * @example 'dsnp://78187493520/bafybeibrueoxoturxz4vfmnc7geejiiqmnygk7os2of32ic3bnr5t6twiy'
+   * @example 'dsnp://78187493520/bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna'
    */
   @IsDsnpContentURI()
   inReplyTo: string;
@@ -124,12 +125,11 @@ export class BatchFileDto implements IBatchFile {
   schemaId: number;
 
   /**
-   * Reference ID of off-chain batch file
+   * CIDv1 of off-chain batch file
    * @example "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
    */
-  @IsString()
-  @MinLength(1)
-  referenceId: string;
+  @IsCidV1()
+  cid: string;
 }
 
 export class BatchFilesDto {

--- a/libs/types/src/interfaces/content-publishing/announcement.interface.ts
+++ b/libs/types/src/interfaces/content-publishing/announcement.interface.ts
@@ -70,7 +70,7 @@ export interface IBatchFile {
   /**
    * Reference ID of off-chain batch file
    */
-  referenceId: string;
+  cid: string;
 }
 
 export type IRequestType = IBroadcast | IReply | IReaction | IUpdate | IProfile | ITombstone;

--- a/libs/utils/src/decorators/is-cidv1.decorator.spec.ts
+++ b/libs/utils/src/decorators/is-cidv1.decorator.spec.ts
@@ -1,0 +1,68 @@
+import * as ipfsHash from 'ipfs-only-hash';
+import { validate } from 'class-validator';
+import { CID } from 'multiformats';
+import { IsCidV1 } from './is-cidv1.decorator';
+import { calculateIpfsCID } from '#utils/common/common.utils';
+
+class TestClass {
+  @IsCidV1()
+  cid: string;
+}
+
+describe('IsCidV1', () => {
+  it('should pass for valid CIDv1', async () => {
+    const testObj = new TestClass();
+    testObj.cid = await calculateIpfsCID(Buffer.from('test value'));
+
+    const errors = await validate(testObj);
+    expect(errors.length).toBe(0);
+  });
+
+  it('should fail for invalid CID', async () => {
+    const testObj = new TestClass();
+    testObj.cid = 'Invalid hash value';
+
+    const errors = await validate(testObj);
+    expect(errors.length).toBe(1);
+    expect(errors[0].constraints).toHaveProperty('isCidV1');
+    expect(errors[0].constraints.isCidV1).toBe('cid should be a valid CIDv1!');
+  });
+
+  it('should fail for empty string', async () => {
+    const testObj = new TestClass();
+    testObj.cid = '';
+
+    const errors = await validate(testObj);
+    expect(errors.length).toBe(1);
+    expect(errors[0].constraints).toHaveProperty('isCidV1');
+  });
+
+  it('should fail for null', async () => {
+    const testObj = new TestClass();
+    testObj.cid = null;
+
+    const errors = await validate(testObj);
+    expect(errors.length).toBe(1);
+    expect(errors[0].constraints).toHaveProperty('isCidV1');
+  });
+
+  it('should fail for undefined', async () => {
+    const testObj = new TestClass();
+    testObj.cid = undefined;
+
+    const errors = await validate(testObj);
+    expect(errors.length).toBe(1);
+    expect(errors[0].constraints).toHaveProperty('isCidV1');
+  });
+
+  it('should fail for CIDv0', async () => {
+    const testObj = new TestClass();
+    testObj.cid = CID.parse(await ipfsHash.of(Buffer.from('test value')))
+      .toV0()
+      .toString();
+
+    const errors = await validate(testObj);
+    expect(errors.length).toBe(1);
+    expect(errors[0].constraints).toHaveProperty('isCidV1');
+  });
+});

--- a/libs/utils/src/decorators/is-cidv1.decorator.ts
+++ b/libs/utils/src/decorators/is-cidv1.decorator.ts
@@ -1,0 +1,43 @@
+import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
+import { CID } from 'multiformats';
+
+export function validateCidV1(value: unknown): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  try {
+    const cid = CID.parse(value);
+
+    if (cid.version !== 1) {
+      return false;
+    }
+  } catch (err: any) {
+    return false;
+  }
+  return true;
+}
+
+export function IsCidV1(validationOptions?: ValidationOptions) {
+  // eslint-disable-next-line func-names
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isCidV1',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, _args: ValidationArguments) {
+          if (!validateCidV1(value)) {
+            return false;
+          }
+
+          return true;
+        },
+        defaultMessage(args?: ValidationArguments): string {
+          return `${args.property} should be a valid CIDv1!`;
+        },
+      },
+    });
+  };
+}

--- a/libs/utils/src/decorators/is-dsnp-content-hash.decorator.ts
+++ b/libs/utils/src/decorators/is-dsnp-content-hash.decorator.ts
@@ -1,6 +1,5 @@
 import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
 import { base32 } from 'multiformats/bases/base32';
-import { varint } from 'multiformats';
 import { u8aToHex } from '@polkadot/util';
 
 export function validateContentHash(contentHash: unknown): boolean {
@@ -13,36 +12,18 @@ export function validateContentHash(contentHash: unknown): boolean {
   }
 
   try {
-    if (contentHash.length === 46 && contentHash.startsWith('Qm')) {
-      console.error('CIDv0 unsupported');
-      return false; // CIDv0 unsupported
-    }
-
     const decoded = base32.decode(contentHash.toLowerCase());
-
-    const [version, versionLength] = varint.decode(decoded, 0);
-    // version <= 0 is malformed
-    // version == 1 is CIDv1
-    // version > 1 is reserved for future use
-    if (version !== 1) {
-      console.error(`Unsupported CID version: ${version}`);
+    // check multihash size hash identifier 2 bytes + hash value 32 bytes
+    if (decoded.length !== 34) {
       return false;
     }
-
-    const [_multicodec, multicodecLength] = varint.decode(decoded, versionLength);
-    const hash = decoded.slice(versionLength + multicodecLength);
-
-    const hex = u8aToHex(hash).toLowerCase();
-
-    // The DSNP spec only allows Blake3 or SHA2-256 hashes: https://spec.dsnp.org/DSNP/Identifiers.html#supported-hashing-algorithms
+    const hex = u8aToHex(decoded).toLowerCase();
     // check blake3   hash 0x1e20 -> 0x1e for (blake3)   and hash length (0x20 for 32 bytes)
     // check sha2-256 hash 0x1220 -> 0x12 for (sha2-256) and hash length (0x20 for 32 bytes)
     if (!(hex.startsWith('0x1e20') || hex.startsWith('0x1220'))) {
-      console.error(`Unsupported hashing algorithm: ${hex.slice(0, 4)} (${contentHash})`);
       return false;
     }
   } catch (err: any) {
-    console.error(`ERROR: ${JSON.stringify(err)}`);
     return false;
   }
   return true;


### PR DESCRIPTION
- Revert erroneous changes that were made to the DTO validator `@IsDsnpContentHash()` in PR #720
- Add unit tests for validation of spec-supported encoding (base32 only) and hashing algo (sha2-256 or blake3 only) for DSNP content hash
- Add `@IsCidV1()` decorator and unit tests
- Add k6 load tests for recently added endpoints `/v2/content/on-chain` and `v2/content/batchAnnouncement`

Closes #721 