### PR TITLE
fix: update logic for change in property name

### DIFF
--- a/apps/content-publishing-worker/src/interfaces/batch-announcer.job.interface.ts
+++ b/apps/content-publishing-worker/src/interfaces/batch-announcer.job.interface.ts
@@ -10,5 +10,5 @@ export interface IBatchAnnouncerJobData {
 export type IBatchAnnouncerJob = IBatchAnnouncerJobData | IBatchFile;
 
 export function isExistingBatch(data: IBatchAnnouncerJob): data is IBatchFile {
-  return 'referenceId' in data;
+  return 'cid' in data;
 }


### PR DESCRIPTION
Change property name string to reflect property change from `referenceId` to `cid`.

Closes #723 