### PR TITLE
feat: eliminate some chain RPC calls in favor of cached values

### DIFF
--- a/apps/account-api/src/services/handles.service.ts
+++ b/apps/account-api/src/services/handles.service.ts
@@ -23,7 +23,7 @@ export class HandlesService {
   }
 
   async getExpiration(): Promise<number> {
-    const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+    const lastFinalizedBlockNumber = await this.blockchainService.getLatestBlockNumber();
     // standard expiration in SIWF is 10 minutes
     return lastFinalizedBlockNumber + 600 / BlockchainConstants.SECONDS_PER_BLOCK;
   }

--- a/apps/account-api/src/services/keys.service.ts
+++ b/apps/account-api/src/services/keys.service.ts
@@ -80,7 +80,7 @@ export class KeysService {
   }
 
   private async getExpiration(): Promise<number> {
-    const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+    const lastFinalizedBlockNumber = await this.blockchainService.getLatestBlockNumber();
     // standard expiration in SIWF is 10 minutes
     return lastFinalizedBlockNumber + 600 / BlockchainConstants.SECONDS_PER_BLOCK;
   }

--- a/apps/account-worker/src/transaction_notifier/notifier.service.ts
+++ b/apps/account-worker/src/transaction_notifier/notifier.service.ts
@@ -29,7 +29,7 @@ export class TxnNotifierService
     const pendingTxns = await this.cacheManager.hkeys(TXN_WATCH_LIST_KEY);
     // If no transactions pending, skip to end of chain at startup
     if (pendingTxns.length === 0) {
-      const blockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const blockNumber = await this.blockchainService.getLatestBlockNumber();
       await this.setLastSeenBlockNumber(blockNumber);
     }
     this.schedulerRegistry.addInterval(

--- a/apps/account-worker/src/transaction_publisher/publisher.module.ts
+++ b/apps/account-worker/src/transaction_publisher/publisher.module.ts
@@ -6,6 +6,6 @@ import { TransactionPublisherService } from './publisher.service';
 @Module({
   imports: [],
   providers: [TransactionPublisherService],
-  exports: [TransactionPublisherService],
+  exports: [],
 })
 export class TransactionPublisherModule {}

--- a/apps/account-worker/src/worker.config.ts
+++ b/apps/account-worker/src/worker.config.ts
@@ -57,5 +57,15 @@ export default registerAs('account-worker', (): IAccountWorkerConfig => {
     },
   };
 
+  Object.keys(process.env)
+    .filter((key) => /_QUEUE_WORKER_CONCURRENCY/.test(key))
+    .forEach((key) => {
+      const queueName = key.replace(/_QUEUE_WORKER_CONCURRENCY/, '');
+      configs[`${queueName}QueueWorkerConcurrency`] = {
+        value: process.env[key],
+        joi: Joi.number().max(250).min(1),
+      };
+    });
+
   return JoiUtils.validate<IAccountWorkerConfig>(configs);
 });

--- a/apps/content-publishing-worker/src/asset_processor/asset.processor.service.ts
+++ b/apps/content-publishing-worker/src/asset_processor/asset.processor.service.ts
@@ -13,7 +13,7 @@ import { IpfsService } from '#storage';
 @Processor(QueueConstants.ASSET_QUEUE_NAME)
 export class AssetProcessorService extends BaseConsumer implements OnApplicationBootstrap {
   public onApplicationBootstrap() {
-    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`];
+    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 1;
   }
 
   constructor(

--- a/apps/content-publishing-worker/src/asset_processor/asset.processor.service.ts
+++ b/apps/content-publishing-worker/src/asset_processor/asset.processor.service.ts
@@ -1,6 +1,6 @@
 import { InjectRedis } from '@songkeys/nestjs-redis';
 import { Processor, OnWorkerEvent } from '@nestjs/bullmq';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import Redis from 'ioredis';
 import { IAssetJob } from '#types/interfaces/content-publishing';
@@ -11,11 +11,16 @@ import { IpfsService } from '#storage';
 
 @Injectable()
 @Processor(QueueConstants.ASSET_QUEUE_NAME)
-export class AssetProcessorService extends BaseConsumer {
+export class AssetProcessorService extends BaseConsumer implements OnApplicationBootstrap {
+  public onApplicationBootstrap() {
+    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`];
+  }
+
   constructor(
     @InjectRedis() private redis: Redis,
     @Inject(workerConfig.KEY) private readonly config: IContentPublishingWorkerConfig,
     private ipfsService: IpfsService,
+    @Inject(workerConfig.KEY) private readonly cpWorkerConfig: IContentPublishingWorkerConfig,
   ) {
     super();
   }

--- a/apps/content-publishing-worker/src/batching_processor/workers/profile.worker.ts
+++ b/apps/content-publishing-worker/src/batching_processor/workers/profile.worker.ts
@@ -1,19 +1,24 @@
 import { Announcement } from '#types/interfaces/content-publishing';
 import { ContentPublishingQueues as QueueConstants } from '#types/constants';
 import { Processor, OnWorkerEvent } from '@nestjs/bullmq';
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { BaseConsumer } from '#consumer';
 import { BatchingProcessorService } from '../batching.processor.service';
+import workerConfig, { IContentPublishingWorkerConfig } from '#content-publishing-worker/worker.config';
 
 @Injectable()
-@Processor(QueueConstants.PROFILE_QUEUE_NAME, { concurrency: 2 })
+@Processor(QueueConstants.PROFILE_QUEUE_NAME)
 export class ProfileWorker extends BaseConsumer implements OnApplicationBootstrap {
-  constructor(private batchingProcessorService: BatchingProcessorService) {
+  constructor(
+    private batchingProcessorService: BatchingProcessorService,
+    @Inject(workerConfig.KEY) private readonly cpWorkerConfig: IContentPublishingWorkerConfig,
+  ) {
     super();
   }
 
   async onApplicationBootstrap() {
+    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 2;
     return this.batchingProcessorService.setupActiveBatchTimeout(QueueConstants.PROFILE_QUEUE_NAME);
   }
 

--- a/apps/content-publishing-worker/src/batching_processor/workers/reaction.worker.ts
+++ b/apps/content-publishing-worker/src/batching_processor/workers/reaction.worker.ts
@@ -1,19 +1,24 @@
 import { Announcement } from '#types/interfaces/content-publishing';
 import { ContentPublishingQueues as QueueConstants } from '#types/constants';
 import { Processor, OnWorkerEvent } from '@nestjs/bullmq';
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { BaseConsumer } from '#consumer';
 import { BatchingProcessorService } from '../batching.processor.service';
+import workerConfig, { IContentPublishingWorkerConfig } from '#content-publishing-worker/worker.config';
 
 @Injectable()
-@Processor(QueueConstants.REACTION_QUEUE_NAME, { concurrency: 2 })
+@Processor(QueueConstants.REACTION_QUEUE_NAME)
 export class ReactionWorker extends BaseConsumer implements OnApplicationBootstrap {
-  constructor(private batchingProcessorService: BatchingProcessorService) {
+  constructor(
+    private batchingProcessorService: BatchingProcessorService,
+    @Inject(workerConfig.KEY) private readonly cpWorkerConfig: IContentPublishingWorkerConfig,
+  ) {
     super();
   }
 
   async onApplicationBootstrap() {
+    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 2;
     return this.batchingProcessorService.setupActiveBatchTimeout(QueueConstants.REACTION_QUEUE_NAME);
   }
 

--- a/apps/content-publishing-worker/src/batching_processor/workers/reply.worker.ts
+++ b/apps/content-publishing-worker/src/batching_processor/workers/reply.worker.ts
@@ -1,19 +1,24 @@
 import { Announcement } from '#types/interfaces/content-publishing';
 import { ContentPublishingQueues as QueueConstants } from '#types/constants';
 import { Processor, OnWorkerEvent } from '@nestjs/bullmq';
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { BaseConsumer } from '#consumer';
 import { BatchingProcessorService } from '../batching.processor.service';
+import workerConfig, { IContentPublishingWorkerConfig } from '#content-publishing-worker/worker.config';
 
 @Injectable()
 @Processor(QueueConstants.REPLY_QUEUE_NAME, { concurrency: 2 })
 export class ReplyWorker extends BaseConsumer implements OnApplicationBootstrap {
-  constructor(private batchingProcessorService: BatchingProcessorService) {
+  constructor(
+    private batchingProcessorService: BatchingProcessorService,
+    @Inject(workerConfig.KEY) private readonly cpWorkerConfig: IContentPublishingWorkerConfig,
+  ) {
     super();
   }
 
   async onApplicationBootstrap() {
+    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 2;
     return this.batchingProcessorService.setupActiveBatchTimeout(QueueConstants.REPLY_QUEUE_NAME);
   }
 

--- a/apps/content-publishing-worker/src/batching_processor/workers/tombstone.worker.ts
+++ b/apps/content-publishing-worker/src/batching_processor/workers/tombstone.worker.ts
@@ -1,19 +1,24 @@
 import { Announcement } from '#types/interfaces/content-publishing';
 import { ContentPublishingQueues as QueueConstants } from '#types/constants';
 import { Processor, OnWorkerEvent } from '@nestjs/bullmq';
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { BaseConsumer } from '#consumer';
 import { BatchingProcessorService } from '../batching.processor.service';
+import workerConfig, { IContentPublishingWorkerConfig } from '#content-publishing-worker/worker.config';
 
 @Injectable()
 @Processor(QueueConstants.TOMBSTONE_QUEUE_NAME, { concurrency: 2 })
 export class TombstoneWorker extends BaseConsumer implements OnApplicationBootstrap {
-  constructor(private batchingProcessorService: BatchingProcessorService) {
+  constructor(
+    private batchingProcessorService: BatchingProcessorService,
+    @Inject(workerConfig.KEY) private readonly cpWorkerConfig: IContentPublishingWorkerConfig,
+  ) {
     super();
   }
 
   async onApplicationBootstrap() {
+    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 2;
     return this.batchingProcessorService.setupActiveBatchTimeout(QueueConstants.TOMBSTONE_QUEUE_NAME);
   }
 

--- a/apps/content-publishing-worker/src/batching_processor/workers/update.worker.ts
+++ b/apps/content-publishing-worker/src/batching_processor/workers/update.worker.ts
@@ -1,19 +1,24 @@
 import { Announcement } from '#types/interfaces/content-publishing';
 import { ContentPublishingQueues as QueueConstants } from '#types/constants';
 import { Processor, OnWorkerEvent } from '@nestjs/bullmq';
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { BaseConsumer } from '#consumer';
 import { BatchingProcessorService } from '../batching.processor.service';
+import workerConfig, { IContentPublishingWorkerConfig } from '#content-publishing-worker/worker.config';
 
 @Injectable()
 @Processor(QueueConstants.UPDATE_QUEUE_NAME, { concurrency: 2 })
 export class UpdateWorker extends BaseConsumer implements OnApplicationBootstrap {
-  constructor(private batchingProcessorService: BatchingProcessorService) {
+  constructor(
+    private batchingProcessorService: BatchingProcessorService,
+    @Inject(workerConfig.KEY) private readonly cpWorkerConfig: IContentPublishingWorkerConfig,
+  ) {
     super();
   }
 
   async onApplicationBootstrap() {
+    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 2;
     return this.batchingProcessorService.setupActiveBatchTimeout(QueueConstants.UPDATE_QUEUE_NAME);
   }
 

--- a/apps/content-publishing-worker/src/monitor/tx.status.monitor.service.ts
+++ b/apps/content-publishing-worker/src/monitor/tx.status.monitor.service.ts
@@ -23,7 +23,7 @@ export class TxStatusMonitoringService extends BlockchainScannerService {
     const pendingTxns = await this.cacheManager.hkeys(TXN_WATCH_LIST_KEY);
     // If no transactions pending, skip to end of chain at startup
     if (pendingTxns.length === 0) {
-      const blockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const blockNumber = await this.blockchainService.getLatestBlockNumber();
       await this.setLastSeenBlockNumber(blockNumber);
     }
     this.schedulerRegistry.addInterval(

--- a/apps/content-publishing-worker/src/publisher/message.publisher.ts
+++ b/apps/content-publishing-worker/src/publisher/message.publisher.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ISubmittableResult } from '@polkadot/types/types';
 import { SubmittableExtrinsic } from '@polkadot/api-base/types';
 import { BlockchainService } from '#blockchain/blockchain.service';
-import { HexString } from '@polkadot/util/types';
 import { IPublisherJob, isIpfsJob } from '#types/interfaces/content-publishing';
 
 @Injectable()
@@ -13,9 +12,7 @@ export class MessagePublisher {
     this.logger = new Logger(MessagePublisher.name);
   }
 
-  public async publish(
-    message: IPublisherJob,
-  ): Promise<[SubmittableExtrinsic<'promise', ISubmittableResult>, HexString]> {
+  public async publish(message: IPublisherJob): ReturnType<MessagePublisher['processSingleBatch']> {
     const tx = isIpfsJob(message)
       ? this.blockchainService.generateAddIpfsMessage(message.schemaId, message.data.cid, message.data.payloadLength)
       : this.blockchainService.generateAddOnchainMessage(
@@ -28,7 +25,7 @@ export class MessagePublisher {
 
   async processSingleBatch(
     tx: SubmittableExtrinsic<'promise', ISubmittableResult>,
-  ): Promise<[SubmittableExtrinsic<'promise', ISubmittableResult>, HexString]> {
+  ): ReturnType<BlockchainService['payWithCapacity']> {
     this.logger.debug(`Submitting tx of size ${tx.length}`);
     try {
       return this.blockchainService.payWithCapacity(tx);

--- a/apps/content-publishing-worker/src/publisher/publishing.service.ts
+++ b/apps/content-publishing-worker/src/publisher/publishing.service.ts
@@ -59,7 +59,7 @@ export class PublishingService extends BaseConsumer implements OnApplicationBoot
         throw new DelayedError();
       }
       this.logger.log(`Processing job ${job.id} of type ${job.name}`);
-      const currentBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const currentBlockNumber = await this.blockchainService.getLatestBlockNumber();
 
       // Check for valid delegation if appropriate (chain would reject anyway, but this saves Capacity)
       if (isOnChainJob(jobData) && typeof jobData.data.onBehalfOf !== 'undefined') {

--- a/apps/content-publishing-worker/src/publisher/publishing.service.ts
+++ b/apps/content-publishing-worker/src/publisher/publishing.service.ts
@@ -18,11 +18,10 @@ import { MessagePublisher } from './message.publisher';
 import { IContentTxStatus, IPublisherJob, isOnChainJob } from '#types/interfaces';
 import { CapacityCheckerService } from '#blockchain/capacity-checker.service';
 import blockchainConfig, { IBlockchainConfig } from '#blockchain/blockchain.config';
+import workerConfig, { IContentPublishingWorkerConfig } from '#content-publishing-worker/worker.config';
 
 @Injectable()
-@Processor(QueueConstants.PUBLISH_QUEUE_NAME, {
-  concurrency: 2,
-})
+@Processor(QueueConstants.PUBLISH_QUEUE_NAME)
 export class PublishingService extends BaseConsumer implements OnApplicationBootstrap, OnModuleDestroy {
   constructor(
     @InjectRedis() private cacheManager: Redis,
@@ -33,11 +32,13 @@ export class PublishingService extends BaseConsumer implements OnApplicationBoot
     private schedulerRegistry: SchedulerRegistry,
     private eventEmitter: EventEmitter2,
     private capacityCheckerService: CapacityCheckerService,
+    @Inject(workerConfig.KEY) private readonly cpWorkerConfig: IContentPublishingWorkerConfig,
   ) {
     super();
   }
 
   public async onApplicationBootstrap() {
+    this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 2;
     await this.capacityCheckerService.checkForSufficientCapacity();
   }
 

--- a/apps/content-publishing-worker/src/request_processor/request.processor.service.ts
+++ b/apps/content-publishing-worker/src/request_processor/request.processor.service.ts
@@ -1,5 +1,5 @@
 import { Processor } from '@nestjs/bullmq';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { DelayedError, Job } from 'bullmq';
 import { MILLISECONDS_PER_SECOND } from 'time-constants';
 import { IRequestJob } from '#types/interfaces/content-publishing';
@@ -11,7 +11,11 @@ import { IpfsService } from '#storage';
 
 @Injectable()
 @Processor(QueueConstants.REQUEST_QUEUE_NAME)
-export class RequestProcessorService extends BaseConsumer {
+export class RequestProcessorService extends BaseConsumer implements OnApplicationBootstrap {
+  onApplicationBootstrap() {
+    this.worker.concurrency = this.config[`${this.worker.name}QueueWorkerConcurrency`] || 1;
+  }
+
   constructor(
     private dsnpAnnouncementProcessor: DsnpAnnouncementProcessor,
     @Inject(workerConfig.KEY) private readonly config: IContentPublishingWorkerConfig,

--- a/apps/content-publishing-worker/src/worker.config.ts
+++ b/apps/content-publishing-worker/src/worker.config.ts
@@ -39,5 +39,15 @@ export default registerAs('content-publishing-worker', (): IContentPublishingWor
     },
   };
 
+  Object.keys(process.env)
+    .filter((key) => /_QUEUE_WORKER_CONCURRENCY/.test(key))
+    .forEach((key) => {
+      const queueName = key.replace(/_QUEUE_WORKER_CONCURRENCY/, '');
+      configs[`${queueName}QueueWorkerConcurrency`] = {
+        value: process.env[key],
+        joi: Joi.number().max(250).min(1),
+      };
+    });
+
   return JoiUtils.validate<IContentPublishingWorkerConfig>(configs);
 });

--- a/apps/content-watcher/src/api.config.ts
+++ b/apps/content-watcher/src/api.config.ts
@@ -24,5 +24,15 @@ export default registerAs('content-watcher-api', (): IContentWatcherApiConfig =>
     },
   };
 
+  Object.keys(process.env)
+    .filter((key) => /_QUEUE_WORKER_CONCURRENCY/.test(key))
+    .forEach((key) => {
+      const queueName = key.replace(/_QUEUE_WORKER_CONCURRENCY/, '');
+      configs[`${queueName}QueueWorkerConcurrency`] = {
+        value: process.env[key],
+        joi: Joi.number().max(250).min(1),
+      };
+    });
+
   return JoiUtils.validate<IContentWatcherApiConfig>(configs);
 });

--- a/apps/content-watcher/src/crawler/crawler.service.ts
+++ b/apps/content-watcher/src/crawler/crawler.service.ts
@@ -34,7 +34,7 @@ export class CrawlerService extends BaseConsumer {
     // we can access from the node
     try {
       let { upperBoundBlock } = job.data;
-      const latestBlock = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const latestBlock = await this.blockchainService.getLatestBlockNumber();
       if (!upperBoundBlock) {
         upperBoundBlock = latestBlock;
         this.logger.debug(`No starting block specified; starting from end of chain at block ${upperBoundBlock}`);

--- a/apps/content-watcher/src/pubsub/announcers/broadcast.ts
+++ b/apps/content-watcher/src/pubsub/announcers/broadcast.ts
@@ -1,15 +1,23 @@
 import { Processor } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { ContentWatcherQueues as QueueConstants } from '#types/constants/queue.constants';
 import { BaseConsumer } from '#consumer';
 import { PubSubService } from '../pubsub.service';
 import { AnnouncementResponse } from '#types/content-announcement';
+import apiConfig, { IContentWatcherApiConfig } from '#content-watcher/api.config';
 
 @Injectable()
-@Processor(QueueConstants.WATCHER_BROADCAST_QUEUE_NAME, { concurrency: 2 })
-export class BroadcastSubscriber extends BaseConsumer {
-  constructor(private readonly pubsubService: PubSubService) {
+@Processor(QueueConstants.WATCHER_BROADCAST_QUEUE_NAME)
+export class BroadcastSubscriber extends BaseConsumer implements OnApplicationBootstrap {
+  public onApplicationBootstrap() {
+    this.worker.concurrency = this.config[`${this.worker.name}QueueWorkerConcurrency`] || 2;
+  }
+
+  constructor(
+    private readonly pubsubService: PubSubService,
+    @Inject(apiConfig.KEY) private readonly config: IContentWatcherApiConfig,
+  ) {
     super();
   }
 

--- a/apps/content-watcher/src/pubsub/announcers/profile.ts
+++ b/apps/content-watcher/src/pubsub/announcers/profile.ts
@@ -1,15 +1,23 @@
 import { Processor } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { ContentWatcherQueues as QueueConstants } from '#types/constants/queue.constants';
 import { BaseConsumer } from '#consumer';
 import { PubSubService } from '../pubsub.service';
 import { AnnouncementResponse } from '#types/content-announcement';
+import apiConfig, { IContentWatcherApiConfig } from '#content-watcher/api.config';
 
 @Injectable()
 @Processor(QueueConstants.WATCHER_PROFILE_QUEUE_NAME, { concurrency: 2 })
-export class ProfileSubscriber extends BaseConsumer {
-  constructor(private readonly pubsubService: PubSubService) {
+export class ProfileSubscriber extends BaseConsumer implements OnApplicationBootstrap {
+  public onApplicationBootstrap() {
+    this.worker.concurrency = this.config[`${this.worker.name}QueueWorkerConcurrency`] || 2;
+  }
+
+  constructor(
+    private readonly pubsubService: PubSubService,
+    @Inject(apiConfig.KEY) private readonly config: IContentWatcherApiConfig,
+  ) {
     super();
   }
 

--- a/apps/content-watcher/src/pubsub/announcers/reaction.ts
+++ b/apps/content-watcher/src/pubsub/announcers/reaction.ts
@@ -1,15 +1,23 @@
 import { Processor } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { ContentWatcherQueues as QueueConstants } from '#types/constants/queue.constants';
 import { BaseConsumer } from '#consumer';
 import { PubSubService } from '../pubsub.service';
 import { AnnouncementResponse } from '#types/content-announcement';
+import apiConfig, { IContentWatcherApiConfig } from '#content-watcher/api.config';
 
 @Injectable()
 @Processor(QueueConstants.WATCHER_REACTION_QUEUE_NAME, { concurrency: 2 })
-export class ReactionSubscriber extends BaseConsumer {
-  constructor(private readonly pubsubService: PubSubService) {
+export class ReactionSubscriber extends BaseConsumer implements OnApplicationBootstrap {
+  public onApplicationBootstrap() {
+    this.worker.concurrency = this.config[`${this.worker.name}QueueWorkerConcurrency`] || 2;
+  }
+
+  constructor(
+    private readonly pubsubService: PubSubService,
+    @Inject(apiConfig.KEY) private readonly config: IContentWatcherApiConfig,
+  ) {
     super();
   }
 

--- a/apps/content-watcher/src/pubsub/announcers/tombstone.ts
+++ b/apps/content-watcher/src/pubsub/announcers/tombstone.ts
@@ -1,15 +1,23 @@
 import { Processor } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { ContentWatcherQueues as QueueConstants } from '#types/constants/queue.constants';
 import { BaseConsumer } from '#consumer';
 import { PubSubService } from '../pubsub.service';
 import { AnnouncementResponse } from '#types/content-announcement';
+import apiConfig, { IContentWatcherApiConfig } from '#content-watcher/api.config';
 
 @Injectable()
 @Processor(QueueConstants.WATCHER_TOMBSTONE_QUEUE_NAME, { concurrency: 2 })
-export class TomstoneSubscriber extends BaseConsumer {
-  constructor(private readonly pubsubService: PubSubService) {
+export class TomstoneSubscriber extends BaseConsumer implements OnApplicationBootstrap {
+  public onApplicationBootstrap() {
+    this.worker.concurrency = this.config[`${this.worker.name}QueueWorkerConcurrency`] || 2;
+  }
+
+  constructor(
+    private readonly pubsubService: PubSubService,
+    @Inject(apiConfig.KEY) private readonly config: IContentWatcherApiConfig,
+  ) {
     super();
   }
 

--- a/apps/content-watcher/src/pubsub/announcers/update.ts
+++ b/apps/content-watcher/src/pubsub/announcers/update.ts
@@ -1,15 +1,23 @@
 import { Processor } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { ContentWatcherQueues as QueueConstants } from '#types/constants/queue.constants';
 import { BaseConsumer } from '#consumer';
 import { PubSubService } from '../pubsub.service';
 import { AnnouncementResponse } from '#types/content-announcement';
+import apiConfig, { IContentWatcherApiConfig } from '#content-watcher/api.config';
 
 @Injectable()
 @Processor(QueueConstants.WATCHER_UPDATE_QUEUE_NAME, { concurrency: 2 })
-export class UpdateSubscriber extends BaseConsumer {
-  constructor(private readonly pubsubService: PubSubService) {
+export class UpdateSubscriber extends BaseConsumer implements OnApplicationBootstrap {
+  public onApplicationBootstrap() {
+    this.worker.concurrency = this.config[`${this.worker.name}QueueWorkerConcurrency`] || 2;
+  }
+
+  constructor(
+    private readonly pubsubService: PubSubService,
+    @Inject(apiConfig.KEY) private readonly config: IContentWatcherApiConfig,
+  ) {
     super();
   }
 

--- a/apps/graph-worker/src/graph_notifier/graph.monitor.service.ts
+++ b/apps/graph-worker/src/graph_notifier/graph.monitor.service.ts
@@ -44,7 +44,7 @@ export class GraphMonitorService extends BlockchainScannerService {
     // If no transactions pending, skip to end of chain at startup, else, skip to earliest
     /// birth block of a monitored extrinsic if we haven't crawled that far yet
     if (Object.keys(pendingTxns).length === 0) {
-      const blockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const blockNumber = await this.blockchainService.getLatestBlockNumber();
       this.logger.log(`Skipping to end of the chain to resume scanning (block #${blockNumber})`);
       await this.setLastSeenBlockNumber(blockNumber);
     } else {

--- a/apps/graph-worker/src/graph_publisher/graph.publisher.processor.service.ts
+++ b/apps/graph-worker/src/graph_publisher/graph.publisher.processor.service.ts
@@ -1,6 +1,6 @@
 import { InjectRedis } from '@songkeys/nestjs-redis';
 import { InjectQueue, Processor } from '@nestjs/bullmq';
-import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common';
 import { DelayedError, Job, Queue } from 'bullmq';
 import Redis from 'ioredis';
 import { SubmittableExtrinsic } from '@polkadot/api-base/types';
@@ -18,6 +18,7 @@ import blockchainConfig, { IBlockchainConfig } from '#blockchain/blockchain.conf
 import { BlockchainService } from '#blockchain/blockchain.service';
 import { ICapacityInfo } from '#blockchain/types';
 import { HexString } from '@polkadot/util/types';
+import workerConfig, { IGraphWorkerConfig } from '#graph-worker/worker.config';
 
 const CAPACITY_EPOCH_TIMEOUT_NAME = 'capacity_check';
 
@@ -26,8 +27,9 @@ const CAPACITY_EPOCH_TIMEOUT_NAME = 'capacity_check';
  */
 @Injectable()
 @Processor(QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE)
-export class GraphUpdatePublisherService extends BaseConsumer implements OnApplicationShutdown {
+export class GraphUpdatePublisherService extends BaseConsumer implements OnApplicationBootstrap, OnApplicationShutdown {
   public async onApplicationBootstrap() {
+    this.worker.concurrency = this.graphWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 1;
     await this.capacityCheckerService.checkForSufficientCapacity();
   }
 
@@ -44,6 +46,7 @@ export class GraphUpdatePublisherService extends BaseConsumer implements OnAppli
     @InjectRedis() private cacheManager: Redis,
     @InjectQueue(QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE) private graphChangePublishQueue: Queue,
     @Inject(blockchainConfig.KEY) private readonly blockchainConf: IBlockchainConfig,
+    @Inject(workerConfig.KEY) private readonly graphWorkerConfig: IGraphWorkerConfig,
     private blockchainService: BlockchainService,
     private capacityCheckerService: CapacityCheckerService,
     private schedulerRegistry: SchedulerRegistry,

--- a/apps/graph-worker/src/graph_publisher/graph.publisher.processor.service.ts
+++ b/apps/graph-worker/src/graph_publisher/graph.publisher.processor.service.ts
@@ -63,7 +63,7 @@ export class GraphUpdatePublisherService extends BaseConsumer implements OnAppli
     let successMethod: string;
     try {
       this.logger.log(`Processing job ${job.id} of type ${job.name}`);
-      const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const lastFinalizedBlockNumber = await this.blockchainService.getLatestBlockNumber();
       switch (job.data.update.type) {
         case 'PersistPage': {
           successMethod = 'PaginatedPageUpdated';

--- a/apps/graph-worker/src/worker.config.ts
+++ b/apps/graph-worker/src/worker.config.ts
@@ -19,5 +19,15 @@ export default registerAs('graph-worker', (): IGraphWorkerConfig => {
     },
   };
 
+  Object.keys(process.env)
+    .filter((key) => /_QUEUE_WORKER_CONCURRENCY/.test(key))
+    .forEach((key) => {
+      const queueName = key.replace(/_QUEUE_WORKER_CONCURRENCY/, '');
+      configs[`${queueName}QueueWorkerConcurrency`] = {
+        value: process.env[key],
+        joi: Joi.number().max(250).min(1),
+      };
+    });
+
   return JoiUtils.validate<IGraphWorkerConfig>(configs);
 });

--- a/libs/account-lib/src/utils/blockchain-scanner.service.spec.ts
+++ b/libs/account-lib/src/utils/blockchain-scanner.service.spec.ts
@@ -122,7 +122,7 @@ describe('BlockchainScannerService', () => {
       .mockImplementation((blockNumber: BlockNumber | AnyNumber) =>
         Promise.resolve((blockNumber as unknown as number) > 1 ? mockEmptyBlockHash : mockBlockHash),
       );
-    jest.spyOn(blockchainService, 'getLatestFinalizedBlockNumber');
+    jest.spyOn(blockchainService, 'getLatestBlockNumber');
     jest.spyOn(blockchainService, 'getEvents').mockResolvedValue([]);
     mockApi.emit('connected'); // keeps the test suite from hanging when finished
   });
@@ -141,7 +141,7 @@ describe('BlockchainScannerService', () => {
     beforeEach(() => {
       jest.restoreAllMocks();
       service.scanParameters = { onlyFinalized: true };
-      jest.spyOn(blockchainService, 'getLatestFinalizedBlockNumber').mockResolvedValue(latestFinalizedBlockNumber);
+      jest.spyOn(blockchainService, 'getLatestBlockNumber').mockResolvedValue(latestFinalizedBlockNumber);
     });
 
     afterAll(() => {

--- a/libs/account-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/account-lib/src/utils/blockchain-scanner.service.ts
@@ -145,7 +145,7 @@ export abstract class BlockchainScannerService {
     }
 
     if (this.scanParameters?.onlyFinalized) {
-      const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const lastFinalizedBlockNumber = await this.blockchainService.getLatestBlockNumber();
       if (blockNumber > lastFinalizedBlockNumber) {
         throw new EndOfChainError(`Latest finalized block (${lastFinalizedBlockNumber}) encountered`);
       }

--- a/libs/blockchain/src/blockchain.module.ts
+++ b/libs/blockchain/src/blockchain.module.ts
@@ -22,9 +22,8 @@ export class BlockchainModule {
       : { provide: BlockchainRpcQueryService, useExisting: BlockchainService };
 
     BlockchainModule.services = [
-      CapacityCheckerService,
       BlockchainRpcQueryProvider,
-      ...(readOnly ? [] : [BlockchainService]),
+      ...(readOnly ? [] : [BlockchainService, CapacityCheckerService]),
     ];
     BlockchainModule.isConfigured = true;
 

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -193,7 +193,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     let nonce: string | number = await this.nonceRedis.get(currentNonceKey);
     if (!nonce) {
       nonce = await this.getNonce(this.accountId);
-      await this.nonceRedis.setex(currentNonceKey, NONCE_KEY_EXPIRE_SECONDS, nonce);
+      await this.nonceRedis.setex(currentNonceKey, NONCE_KEY_EXPIRE_SECONDS / 2, nonce);
     }
     const keys = getNextPossibleNonceKeys(this.accountId, nonce);
     // @ts-ignore

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -291,7 +291,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
 
   /**
    * Gets the block hash and number of the latest block for signing. We cache this info & update asynchronously. This
-   * elminates unnecessary RPC calls to get the latest block info, since it's okay if we're a little behind in the block number/hash we
+   * eliminates unnecessary RPC calls to get the latest block info, since it's okay if we're a little behind in the block number/hash we
    * use for signing and mortality checking.
    * @returns The block hash & number of the latest finalized block if the finality lag is greater than the maximum allowed, otherwise the block hash of the latest block.
    */
@@ -314,7 +314,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
   }
 
   /**
-   * Gets get default mortality period for transactions.
+   * Gets default mortality period for transactions.
    * From: https://github.com/polkadot-js/api/blob/a5c5f76aee54622d004c6b4342040e8c9d149d1e/packages/api-derive/src/tx/signingInfo.ts#L117
    * @returns The default mortality period for transactions.
    */

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -225,7 +225,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
       this.logger.debug(`Tx hash: ${txHash}`);
       return [extrinsic, txHash.toHex(), block.number];
     } catch (err: any) {
-      this.unreserveNonce(nonce);
+      await this.unreserveNonce(nonce);
       throw err;
     }
   }

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -247,7 +247,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     const nonce = await this.reserveNextNonce();
     const block = await this.getBlockForSigning();
     const blockHash = this.api.createType('Hash', block.blockHash);
-    const era = this.api.createType('ExtrinsicEra', { current: blockHash, period: this.defaultMortalityPeriod });
+    const era = this.api.createType('ExtrinsicEra', { current: block.number, period: this.defaultMortalityPeriod });
     try {
       this.logger.debug(`Capacity Wrapped Extrinsic: ${JSON.stringify(extrinsic.toHuman())}, nonce: ${nonce}`);
       const txHash = await extrinsic.signAndSend(keys, { nonce, blockHash, era });
@@ -257,7 +257,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
       this.logger.debug(`Tx hash: ${txHash.toString()}`);
       return [extrinsic, txHash.toHex(), block.number];
     } catch (err: any) {
-      this.unreserveNonce(nonce);
+      await this.unreserveNonce(nonce);
       throw err;
     }
   }

--- a/libs/blockchain/src/capacity-checker.service.ts
+++ b/libs/blockchain/src/capacity-checker.service.ts
@@ -130,7 +130,12 @@ export class CapacityCheckerService implements OnApplicationBootstrap, OnModuleD
 
     try {
       const { capacityLimit } = this.config;
-      const capacityInfo = JSON.parse(await this.redis.get(CURRENT_CHAIN_CAPACITY_KEY)) as ICapacityInfo;
+      const capacityInfo = JSON.parse(await this.redis.get(CURRENT_CHAIN_CAPACITY_KEY), (key, value) => {
+        if (key === 'remainingCapacity' || key === 'totalCapacityIssued') {
+          return BigInt(value);
+        }
+        return value;
+      }) as ICapacityInfo;
 
       // This doesn't really pick up on capacity exhaustion, as usage is unlikely to bring capacity to zero
       // (there will always be some dust). But it will warn in the case where a provider has been completely un-staked

--- a/libs/blockchain/src/polkadot-api.service.ts
+++ b/libs/blockchain/src/polkadot-api.service.ts
@@ -106,6 +106,19 @@ export class PolkadotApiService extends EventEmitter2 implements OnApplicationSh
     return this.api.consts.system.ss58Prefix.toBn().toNumber();
   }
 
+  /**
+   * Gets block time ms from the chain metadata
+   * From: https://github.com/polkadot-js/api/blob/a5c5f76aee54622d004c6b4342040e8c9d149d1e/packages/api-derive/src/tx/signingInfo.ts#L77
+   */
+  public get blockTimeMs(): number {
+    return (
+      this.api.consts.babe?.expectedBlockTime?.toNumber() ||
+      this.api.consts.aura?.slotDuration?.toNumber() ||
+      this.api.consts.timestamp?.minimumPeriod?.muln(2).toNumber() || // timestamp minimum period is half the block time
+      6000 // fallback to a sane default of 6s (ie, metadata hasn't been fetched yet)
+    );
+  }
+
   public async isReady(): Promise<boolean> {
     return (await this.baseIsReadyPromise) && !!(await this.api.isReady);
   }

--- a/libs/content-publishing-lib/src/utils/blockchain-scanner.service.spec.ts
+++ b/libs/content-publishing-lib/src/utils/blockchain-scanner.service.spec.ts
@@ -108,7 +108,7 @@ describe('BlockchainScannerService', () => {
       .mockImplementation((blockNumber: BlockNumber | AnyNumber) =>
         Promise.resolve((blockNumber as unknown as number) > 1 ? mockEmptyBlockHash : mockBlockHash),
       );
-    jest.spyOn(blockchainService, 'getLatestFinalizedBlockNumber');
+    jest.spyOn(blockchainService, 'getLatestBlockNumber');
     jest.spyOn(blockchainService, 'getEvents').mockResolvedValue([]);
 
     mockApi.emit('connected'); // keeps the test suite from hanging when finished
@@ -128,7 +128,7 @@ describe('BlockchainScannerService', () => {
     beforeEach(() => {
       jest.restoreAllMocks();
       service.scanParameters = { onlyFinalized: true };
-      jest.spyOn(blockchainService, 'getLatestFinalizedBlockNumber').mockResolvedValue(latestFinalizedBlockNumber);
+      jest.spyOn(blockchainService, 'getLatestBlockNumber').mockResolvedValue(latestFinalizedBlockNumber);
     });
 
     afterAll(() => {

--- a/libs/content-publishing-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/content-publishing-lib/src/utils/blockchain-scanner.service.ts
@@ -148,7 +148,7 @@ export abstract class BlockchainScannerService {
     }
 
     if (this.scanParameters?.onlyFinalized) {
-      const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const lastFinalizedBlockNumber = await this.blockchainService.getLatestBlockNumber();
       if (blockNumber > lastFinalizedBlockNumber) {
         throw new EndOfChainError(`Latest finalized block (${lastFinalizedBlockNumber}) encountered`);
       }

--- a/libs/content-watcher-lib/src/scanner/scanner.service.ts
+++ b/libs/content-watcher-lib/src/scanner/scanner.service.ts
@@ -75,7 +75,7 @@ export class ScannerService implements OnApplicationBootstrap, OnApplicationShut
 
   public async resetScan({ blockNumber, rewindOffset, immediate }: IScanReset) {
     this.pauseScanner();
-    let targetBlock = blockNumber ?? (await this.blockchainService.getLatestFinalizedBlockNumber());
+    let targetBlock = blockNumber ?? (await this.blockchainService.getLatestBlockNumber());
     targetBlock -= rewindOffset ? Math.abs(rewindOffset) : 0;
     targetBlock = Math.max(targetBlock, 1);
     this.scanResetBlockNumber = targetBlock;
@@ -152,7 +152,7 @@ export class ScannerService implements OnApplicationBootstrap, OnApplicationShut
     } else {
       nextBlock = Number((await this.cache.get(LAST_SEEN_BLOCK_NUMBER_SCANNER_KEY)) ?? '0');
       if (!nextBlock) {
-        nextBlock = await this.blockchainService.getLatestFinalizedBlockNumber();
+        nextBlock = await this.blockchainService.getLatestBlockNumber();
         this.setLastSeenBlockNumber(nextBlock);
       }
 

--- a/libs/graph-lib/src/utils/blockchain-scanner.service.spec.ts
+++ b/libs/graph-lib/src/utils/blockchain-scanner.service.spec.ts
@@ -108,7 +108,7 @@ describe('BlockchainScannerService', () => {
       .mockImplementation((blockNumber: BlockNumber | AnyNumber) =>
         Promise.resolve((blockNumber as unknown as number) > 1 ? mockEmptyBlockHash : mockBlockHash),
       );
-    jest.spyOn(blockchainService, 'getLatestFinalizedBlockNumber');
+    jest.spyOn(blockchainService, 'getLatestBlockNumber');
     jest.spyOn(blockchainService, 'getEvents').mockResolvedValue([]);
 
     mockApi.emit('connected'); // keeps the test suite from hanging when finished
@@ -128,7 +128,7 @@ describe('BlockchainScannerService', () => {
     beforeEach(() => {
       jest.restoreAllMocks();
       service.scanParameters = { onlyFinalized: true };
-      jest.spyOn(blockchainService, 'getLatestFinalizedBlockNumber').mockResolvedValue(latestFinalizedBlockNumber);
+      jest.spyOn(blockchainService, 'getLatestBlockNumber').mockResolvedValue(latestFinalizedBlockNumber);
     });
 
     afterAll(() => {

--- a/libs/graph-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/graph-lib/src/utils/blockchain-scanner.service.ts
@@ -147,7 +147,7 @@ export abstract class BlockchainScannerService {
     }
 
     if (this.scanParameters?.onlyFinalized) {
-      const lastFinalizedBlockNumber = await this.blockchainService.getLatestFinalizedBlockNumber();
+      const lastFinalizedBlockNumber = await this.blockchainService.getLatestBlockNumber();
       if (blockNumber > lastFinalizedBlockNumber) {
         throw new EndOfChainError(`Latest finalized block (${lastFinalizedBlockNumber}) encountered`);
       }

--- a/libs/types/src/constants/redis-keys.constants.ts
+++ b/libs/types/src/constants/redis-keys.constants.ts
@@ -66,7 +66,7 @@ export namespace NonceConstants {
    * temporarily locked keys on redis side and get the first available one. This number defines the number of keys
    * we should look into before giving up
    */
-  export const NUMBER_OF_NONCE_KEYS_TO_CHECK = 50;
+  export const NUMBER_OF_NONCE_KEYS_TO_CHECK = 200;
   /**
    * Nonce keys have to get expired shortly so that if any of nonce numbers get skipped we would still have a way to
    * submit them after expiration

--- a/libs/types/src/constants/redis-keys.constants.ts
+++ b/libs/types/src/constants/redis-keys.constants.ts
@@ -73,8 +73,8 @@ export namespace NonceConstants {
    */
   export const NONCE_KEY_EXPIRE_SECONDS = 2;
   const CHAIN_NONCE_KEY = 'chain:nonce';
-  export function getNonceKey(suffix: string) {
-    return `${CHAIN_NONCE_KEY}:${suffix}`;
+  export function getNonceKey(address: string, suffix: string) {
+    return `${CHAIN_NONCE_KEY}:${address}:${suffix}`;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@nestjs/swagger": "^7.4.2",
         "@polkadot/api": "^15.8.1",
         "@polkadot/api-base": "^15.8.1",
+        "@polkadot/api-derive": "^15.8.1",
         "@polkadot/keyring": "^13.4.3",
         "@polkadot/rpc-provider": "^15.8.1",
         "@polkadot/types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@nestjs/swagger": "^7.4.2",
     "@polkadot/api": "^15.8.1",
     "@polkadot/api-base": "^15.8.1",
+    "@polkadot/api-derive": "^15.8.1",
     "@polkadot/keyring": "^13.4.3",
     "@polkadot/rpc-provider": "^15.8.1",
     "@polkadot/types": "^15.8.1",


### PR DESCRIPTION
This PR attempts to eliminate a number of RPC calls to the chain from the critical path of submitting a transaction. By caching certain values retrieved from the chain, we both increase job throughput in the Gateway services, and reduce load on the chain RPC node.

- Makes all queue workers' concurrencies configurable via env `<queueName>_QUEUE_WORKER_CONCURRENCY`
- Manually specify block hash & era for transaction signing and submission; eliminates anywhere from 3-7 RPC calls to the chain
- Keep current capacity usage and latest nonce updated in Redis cache on a defined interval. This takes it out of the critical path of submitting a transaction. (It's OK not to get the absolute latest from the chain each time)
- If we detect an error submitting a transaction, un-reserve the none key that we submitted

Related issue: #750 