### PR TITLE
fix: change shutdown timer log level and exit code

### DIFF
--- a/apps/account-api/src/main.ts
+++ b/apps/account-api/src/main.ts
@@ -24,8 +24,8 @@ BigInt.prototype['toJSON'] = function () {
  */
 function startShutdownTimer() {
   setTimeout(() => {
-    logger.log('Shutdown timer expired');
-    process.exit(0);
+    logger.warn('Shutdown timer expired');
+    process.exit(1);
   }, 10_000);
 }
 


### PR DESCRIPTION
# Problem

Experienced with Account Service.

Logs from the event:

```
[Nest] 454  - 03/19/2025, 9:54:39 PM    WARN [main] Received shutdown event
[Nest] 454  - 03/19/2025, 9:54:39 PM    WARN [main] app closed
[Nest] 454  - 03/19/2025, 9:54:49 PM     LOG [main] Shutdown timer expired
2025-03-19 21:37:18          API-WS: disconnected from wss://0.rpc.testnet.amplica.io/: 1006:: Abnormal Closure
[Nest] 454  - 03/19/2025, 9:37:18 PM   ERROR [BlockchainRpcQueryService] Communications error with Frequency node; starting 60-second shutdown timer
[Nest] 454  - 03/19/2025, 9:54:39 PM   ERROR [BlockchainRpcQueryService] Failed to reconnect to Frequency node; terminating application
```

Expected: The Container halts

Actual: Container was still running


# Solution

- Change `process.exit(0)` to `process.exit(1)` when the `shutDownTimer` expires. Container orchestration systems are looking for apps to exit with a non-zero error in order to restart.
- Checked all gateway apps to ensure usage of `process.exit(1)`.

Closes #749 


