### PR TITLE
feat: implement dynamic log level configuration across applications

### DIFF
--- a/apps/account-api/src/main.ts
+++ b/apps/account-api/src/main.ts
@@ -7,6 +7,7 @@ import { TimeoutInterceptor } from '#utils/interceptors/timeout.interceptor';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import apiConfig, { IAccountApiConfig } from './api.config';
 import { generateSwaggerDoc, initializeSwaggerUI, writeOpenApiFile } from '#openapi/openapi';
+import { getLogLevels } from 'libs/logger/logLevel-common-config';
 
 const logger = new Logger('main');
 
@@ -93,7 +94,7 @@ async function bootstrap() {
 
     initializeSwaggerUI(app, swaggerDoc);
     logger.log(`Listening on port ${config.apiPort}`);
-    logger.debug('****** DEBUGGING ENABLED ********');
+    logger.log(`Log levels: ${getLogLevels().join(', ')}`);
     await app.listen(config.apiPort);
   } catch (e) {
     logger.log('****** MAIN CATCH ********');

--- a/apps/account-worker/src/main.ts
+++ b/apps/account-worker/src/main.ts
@@ -4,6 +4,7 @@ import { Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { KeepAliveStrategy } from '#utils/common/keepalive-strategy';
 import { WorkerModule } from './worker.module';
+import { getLogLevels } from 'libs/logger/logLevel-common-config';
 
 // Monkey-patch BigInt so that JSON.stringify will work
 // eslint-disable-next-line
@@ -30,7 +31,7 @@ async function bootstrap() {
   });
 
   const app = await NestFactory.createMicroservice(WorkerModule, {
-    logger: process.env.DEBUG ? ['error', 'warn', 'log', 'verbose', 'debug'] : ['error', 'warn', 'log'],
+    logger: getLogLevels(),
     strategy: new KeepAliveStrategy(),
   });
   logger.log('Nest ApplicationContext created successfully.');
@@ -45,6 +46,7 @@ async function bootstrap() {
 
   try {
     app.enableShutdownHooks();
+    logger.log(`Log levels: ${getLogLevels().join(', ')}`);
     await app.listen();
   } catch (e) {
     logger.error('****** MAIN CATCH ********', e);

--- a/apps/content-publishing-api/src/main.ts
+++ b/apps/content-publishing-api/src/main.ts
@@ -6,6 +6,7 @@ import apiConfig, { IContentPublishingApiConfig } from './api.config';
 import { TimeoutInterceptor } from '#utils/interceptors/timeout.interceptor';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { generateSwaggerDoc, initializeSwaggerUI, writeOpenApiFile } from '#openapi/openapi';
+import { getLogLevels } from 'libs/logger/logLevel-common-config';
 
 const logger = new Logger('main');
 
@@ -29,7 +30,7 @@ function startShutdownTimer() {
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(ApiModule, {
-    logger: process.env.DEBUG ? ['error', 'warn', 'log', 'verbose', 'debug'] : ['error', 'warn', 'log'],
+    logger: getLogLevels(),
     rawBody: true,
   });
 
@@ -86,6 +87,7 @@ async function bootstrap() {
 
     initializeSwaggerUI(app, swaggerDoc);
     logger.log(`Listening on port ${config.apiPort}`);
+    logger.log(`Log levels: ${getLogLevels().join(', ')}`);
     await app.listen(config.apiPort);
   } catch (e) {
     logger.log('****** MAIN CATCH ********');

--- a/apps/content-publishing-worker/src/main.ts
+++ b/apps/content-publishing-worker/src/main.ts
@@ -3,6 +3,7 @@ import { WorkerModule } from './worker.module';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Logger } from '@nestjs/common';
 import { KeepAliveStrategy } from '#utils/common/keepalive-strategy';
+import { getLogLevels } from 'libs/logger/logLevel-common-config';
 
 // Monkey-patch BigInt so that JSON.stringify will work
 // eslint-disable-next-line
@@ -26,7 +27,7 @@ function startShutdownTimer() {
 
 async function bootstrap() {
   const app = await NestFactory.createMicroservice(WorkerModule, {
-    logger: process.env.DEBUG ? ['error', 'warn', 'log', 'verbose', 'debug'] : ['error', 'warn', 'log'],
+    logger: getLogLevels(),
     strategy: new KeepAliveStrategy(),
   });
 
@@ -40,6 +41,7 @@ async function bootstrap() {
 
   try {
     app.enableShutdownHooks();
+    logger.log(`Log levels: ${getLogLevels().join(', ')}`);
     await app.listen();
     logger.log('Exiting bootstrap');
   } catch (e) {

--- a/apps/content-watcher/src/main.ts
+++ b/apps/content-watcher/src/main.ts
@@ -6,6 +6,7 @@ import apiConfig, { IContentWatcherApiConfig } from './api.config';
 import { TimeoutInterceptor } from '#utils/interceptors/timeout.interceptor';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { generateSwaggerDoc, initializeSwaggerUI, writeOpenApiFile } from '#openapi/openapi';
+import { getLogLevels } from 'libs/logger/logLevel-common-config';
 
 const logger = new Logger('main');
 
@@ -27,7 +28,7 @@ function startShutdownTimer() {
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(ApiModule, {
-    logger: process.env.DEBUG ? ['error', 'warn', 'log', 'verbose', 'debug'] : ['error', 'warn', 'log'],
+    logger: getLogLevels(),
     rawBody: true,
   });
 
@@ -82,6 +83,7 @@ async function bootstrap() {
 
     initializeSwaggerUI(app, swaggerDoc);
     logger.log(`Listening on port ${config.apiPort}`);
+    logger.log(`Log levels: ${getLogLevels().join(', ')}`);
     await app.listen(config.apiPort);
   } catch (e) {
     await app.close();

--- a/apps/graph-api/src/main.ts
+++ b/apps/graph-api/src/main.ts
@@ -6,6 +6,7 @@ import apiConfig, { IGraphApiConfig } from './api.config';
 import { TimeoutInterceptor } from '#utils/interceptors/timeout.interceptor';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { generateSwaggerDoc, initializeSwaggerUI, writeOpenApiFile } from '#openapi/openapi';
+import { getLogLevels } from 'libs/logger/logLevel-common-config';
 
 const logger = new Logger('main');
 
@@ -27,7 +28,7 @@ function startShutdownTimer() {
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(ApiModule, {
-    logger: process.env.DEBUG ? ['error', 'warn', 'log', 'verbose', 'debug'] : ['error', 'warn', 'log'],
+    logger: getLogLevels(),
     rawBody: true,
   });
 
@@ -82,6 +83,7 @@ async function bootstrap() {
 
     initializeSwaggerUI(app, swaggerDoc);
     logger.log(`Listening on port ${apiConf.apiPort}`);
+    logger.log(`Log levels: ${getLogLevels().join(', ')}`);
     await app.listen(apiConf.apiPort);
   } catch (e) {
     await app.close();

--- a/apps/graph-worker/src/main.ts
+++ b/apps/graph-worker/src/main.ts
@@ -3,6 +3,7 @@ import { WorkerModule } from './worker.module';
 import { Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { KeepAliveStrategy } from '#utils/common/keepalive-strategy';
+import { getLogLevels } from 'libs/logger/logLevel-common-config';
 
 const logger = new Logger('main');
 
@@ -24,6 +25,7 @@ function startShutdownTimer() {
 
 async function bootstrap() {
   const app = await NestFactory.createMicroservice(WorkerModule, {
+    logger: getLogLevels(),
     strategy: new KeepAliveStrategy(),
   });
 
@@ -37,6 +39,7 @@ async function bootstrap() {
 
   try {
     app.enableShutdownHooks();
+    logger.log(`Log levels: ${getLogLevels().join(', ')}`);
     await app.listen();
     logger.log('Exiting bootstrap');
   } catch (e) {

--- a/libs/content-publishing-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/content-publishing-lib/src/utils/blockchain-scanner.service.ts
@@ -113,7 +113,6 @@ export abstract class BlockchainScannerService {
       }
     } catch (e) {
       if (e instanceof EndOfChainError) {
-        this.logger.verbose(e.message);
         return;
       }
 

--- a/libs/content-publishing-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/content-publishing-lib/src/utils/blockchain-scanner.service.ts
@@ -113,7 +113,7 @@ export abstract class BlockchainScannerService {
       }
     } catch (e) {
       if (e instanceof EndOfChainError) {
-        this.logger.debug(e.message);
+        this.logger.verbose(e.message);
         return;
       }
 

--- a/libs/graph-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/graph-lib/src/utils/blockchain-scanner.service.ts
@@ -113,7 +113,6 @@ export abstract class BlockchainScannerService {
       }
     } catch (e) {
       if (e instanceof EndOfChainError) {
-        this.logger.verbose(e.message);
         return;
       }
 

--- a/libs/graph-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/graph-lib/src/utils/blockchain-scanner.service.ts
@@ -113,7 +113,7 @@ export abstract class BlockchainScannerService {
       }
     } catch (e) {
       if (e instanceof EndOfChainError) {
-        this.logger.debug(e.message);
+        this.logger.verbose(e.message);
         return;
       }
 

--- a/libs/logger/logLevel-common-config.ts
+++ b/libs/logger/logLevel-common-config.ts
@@ -1,0 +1,23 @@
+import { LogLevel } from '@nestjs/common';
+
+/**
+ * Determines appropriate log levels based on environment variables
+ * - Always includes 'error', 'warn', and 'log'
+ * - Adds 'debug' when DEBUG env var is present
+ * - Adds 'verbose' when VERBOSE_LOGGING is true or DEBUG=verbose
+ */
+export function getLogLevels(): LogLevel[] {
+  const logLevels: LogLevel[] = ['error', 'warn', 'log'];
+
+  // Enable debug logging if DEBUG is set
+  if (process.env.DEBUG) {
+    logLevels.push('debug');
+  }
+
+  // Add verbose logging if specifically requested
+  if (process.env.VERBOSE_LOGGING || process.env.DEBUG === 'verbose') {
+    logLevels.push('verbose');
+  }
+
+  return logLevels;
+}

--- a/libs/storage/src/ipfs/ipfs.service.ts
+++ b/libs/storage/src/ipfs/ipfs.service.ts
@@ -74,7 +74,7 @@ export class IpfsService {
     const parsedCid = CID.parse(cid);
     const v0Cid = parsedCid.toV0().toString();
 
-    this.logger.debug(`Requesting pin info from IPFS for ${cid} (${v0Cid})`);
+    this.logger.verbose(`Requesting pin info from IPFS for ${cid} (${v0Cid})`);
     try {
       const r = this.ipfs.pin.ls({ paths: v0Cid, type: 'all' });
       // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
# Problem

See #675

# Solution

This PR enhances log level control by refining how the DEBUG environment variable is used and introducing a new VERBOSE_LOGGING variable for more granular configuration.

Changes

- The `DEBUG=true` environment variable now only enables the debug log level.
- To enable both `debug` and `verbose` log levels, set `DEBUG=verbose`.
- `DEBUG` is defined in the docker-compose.yaml file under the common environment section, enabling debug logging across all gateway services by default.

New Feature

- Introduces the `VERBOSE_LOGGING` environment variable to enable `verbose` logging on a per-service basis.

- It is not defined in the shared `docker-compose.yaml`.
- It must be set in the individual `.env.[service]` file.
- For deployments, it can optionally be added to `docker-compose.yaml` as needed.

This setup makes it easier to enable detailed logs across all services or selectively on a per-service basis.

Closes #675 

## Steps to Verify:

1. Use `start.sh` to configure running with dev containers (NOT published containers).
2. Verify debug logging by default.
3. Modify either `.env.[service]` to include `DEBUG=verbose` or `VERBOSE_LOGGING=true`.
4. Use `stop.sh` and then restart the services using `start.sh` so that environment changes will take effect.
5. Verify verbose logging.

