### PR TITLE
feat: allow task retry on nonce conflict error

### DIFF
--- a/apps/content-publishing-worker/src/publisher/message.publisher.ts
+++ b/apps/content-publishing-worker/src/publisher/message.publisher.ts
@@ -3,6 +3,8 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import { SubmittableExtrinsic } from '@polkadot/api-base/types';
 import { BlockchainService } from '#blockchain/blockchain.service';
 import { IPublisherJob, isIpfsJob } from '#types/interfaces/content-publishing';
+import { NonceConflictError } from '#blockchain/types';
+import { DelayedError } from 'bullmq';
 
 @Injectable()
 export class MessagePublisher {
@@ -31,6 +33,9 @@ export class MessagePublisher {
       return this.blockchainService.payWithCapacity(tx);
     } catch (e) {
       this.logger.error(`Error processing batch: ${e}`);
+      if (e instanceof NonceConflictError) {
+        throw new DelayedError();
+      }
       throw e;
     }
   }

--- a/apps/content-publishing-worker/src/publisher/publishing.service.ts
+++ b/apps/content-publishing-worker/src/publisher/publishing.service.ts
@@ -60,7 +60,6 @@ export class PublishingService extends BaseConsumer implements OnApplicationBoot
         throw new DelayedError();
       }
       this.logger.log(`Processing job ${job.id} of type ${job.name}`);
-      const currentBlockNumber = await this.blockchainService.getLatestBlockNumber();
 
       // Check for valid delegation if appropriate (chain would reject anyway, but this saves Capacity)
       if (isOnChainJob(jobData) && typeof jobData.data.onBehalfOf !== 'undefined') {
@@ -73,7 +72,7 @@ export class PublishingService extends BaseConsumer implements OnApplicationBoot
           throw new UnrecoverableError('No valid delegation for schema');
         }
       }
-      const [tx, txHash] = await this.messagePublisher.publish(jobData);
+      const [tx, txHash, currentBlockNumber] = await this.messagePublisher.publish(jobData);
 
       const status: IContentTxStatus = {
         txHash,

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -34,7 +34,7 @@ import { BlockchainRpcQueryService } from './blockchain-rpc-query.service';
 import { NonceConstants } from '#types/constants';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DelayedError } from 'bullmq';
-import { SIWFTxnValues } from './types';
+import { NonceConflictError, RpcError, SIWFTxnValues } from './types';
 import { BN } from '@polkadot/util';
 
 export const NONCE_SERVICE_REDIS_NAMESPACE = 'NonceService';
@@ -226,6 +226,14 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
       return [extrinsic, txHash.toHex(), block.number];
     } catch (err: any) {
       await this.unreserveNonce(nonce);
+      if (err?.name === 'RpcError') {
+        if (/Priority is too low/.test(err?.message)) {
+          throw new NonceConflictError(err);
+        }
+
+        throw new RpcError(err);
+      }
+
       throw err;
     }
   }
@@ -258,6 +266,14 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
       return [extrinsic, txHash.toHex(), block.number];
     } catch (err: any) {
       await this.unreserveNonce(nonce);
+      if (err?.name === 'RpcError') {
+        if (/Priority is too low/.test(err?.message)) {
+          throw new NonceConflictError(err);
+        }
+
+        throw new RpcError(err);
+      }
+
       throw err;
     }
   }

--- a/libs/blockchain/src/types.ts
+++ b/libs/blockchain/src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 /*
  * NOTE: This class is designed to isolate consumers from having to deal with the details of interacting directly
  *       with the Frequency blockchain. To that end, return values of functions should not expose the SCALE-
@@ -34,3 +35,7 @@ export interface ICapacityFeeDetails {
     adjustedWeightFee: bigint;
   };
 }
+
+export class RpcError extends Error {}
+export class NonceConflictError extends RpcError {}
+export class FutureNonceError extends RpcError {}


### PR DESCRIPTION
This PR catches RPC errors on chain extrinsic submission. If the error is due to a nonce conflict, throw a "DelayedError" which will trigger the initiating queue job to go back into the queue for retry (bypassing configured queue retry limits)

Closes #751 