### PR TITLE
feat: log the failed route when a timeout error occurs

### DIFF
--- a/apps/account-api/src/api.config.ts
+++ b/apps/account-api/src/api.config.ts
@@ -26,7 +26,7 @@ export default registerAs('account-api', (): IAccountApiConfig => {
     },
     apiTimeoutMs: {
       value: process.env.API_TIMEOUT_MS,
-      joi: Joi.number().min(1).default(5000),
+      joi: Joi.number().min(1).default(30000),
     },
     siwfNodeRpcUrl: {
       value: process.env.SIWF_NODE_RPC_URL,

--- a/apps/account-worker/src/transaction_publisher/publisher.service.ts
+++ b/apps/account-worker/src/transaction_publisher/publisher.service.ts
@@ -178,7 +178,10 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
   processBatchTxn(
     callVec: Vec<Call> | (Call | IMethod | string | Uint8Array)[],
   ): ReturnType<BlockchainService['payWithCapacityBatchAll']> {
-    this.logger.debug(`processBatchTxn: callVec: ${callVec.map((c) => c.toHuman())}`);
+    this.logger.debug(
+      'processBatchTxn: callVec: ',
+      callVec.map((c) => c.toHuman()),
+    );
     try {
       return this.blockchainService.payWithCapacityBatchAll(callVec);
     } catch (error: any) {

--- a/libs/utils/src/interceptors/interceptors.spec.ts
+++ b/libs/utils/src/interceptors/interceptors.spec.ts
@@ -1,0 +1,71 @@
+import { Controller, Get, HttpStatus, Logger } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { TimeoutInterceptor } from '#utils/interceptors/timeout.interceptor';
+import { NestExpressApplication } from '@nestjs/platform-express';
+
+@Controller()
+class TestController {
+  // eslint-disable-next-line class-methods-use-this
+  @Get('/timeout')
+  public async timeoutTest() {
+    jest.advanceTimersByTime(5000);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  @Get('/notimeout')
+  public notimeout() {}
+}
+
+describe('Timeout Interceptor Tests', () => {
+  let app: NestExpressApplication;
+  let module: TestingModule;
+  let httpServer: any;
+  let interceptor;
+
+  beforeAll(async () => {
+    jest.useFakeTimers();
+    module = await Test.createTestingModule({
+      controllers: [TestController],
+    }).compile();
+
+    app = module.createNestApplication();
+
+    // Uncomment below to see logs when debugging tests
+    module.useLogger(new Logger());
+
+    interceptor = new TimeoutInterceptor(1000);
+    app.useGlobalInterceptors(interceptor);
+
+    await app.init();
+
+    httpServer = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await httpServer.close();
+  });
+
+  it('(GET) /timeout should return OK if request completes in time', async () => {
+    request(httpServer).get('/notimeout').expect(HttpStatus.OK);
+  });
+
+  it(
+    '(GET) /timeout should time out if request is taking too long',
+    async () =>
+      request(httpServer)
+        .get('/timeout')
+        .expect(HttpStatus.REQUEST_TIMEOUT)
+        .expect({ statusCode: HttpStatus.REQUEST_TIMEOUT, message: 'Request Timeout' }),
+    6000,
+  );
+
+  it('(GET) /timeout should log the route if a timeout exception is thrown', async () => {
+    // eslint-disable-next-line prefer-destructuring
+    const logger: Logger = (interceptor as unknown as any).logger;
+    const logSpy = jest.spyOn(logger, 'error');
+    await request(httpServer).get('/timeout');
+    expect(logSpy).toHaveBeenCalledWith(expect.any(String), expect.stringMatching('/timeout'));
+  });
+});

--- a/libs/utils/src/interceptors/interceptors.spec.ts
+++ b/libs/utils/src/interceptors/interceptors.spec.ts
@@ -66,6 +66,6 @@ describe('Timeout Interceptor Tests', () => {
     const logger: Logger = (interceptor as unknown as any).logger;
     const logSpy = jest.spyOn(logger, 'error');
     await request(httpServer).get('/timeout');
-    expect(logSpy).toHaveBeenCalledWith(expect.any(String), expect.stringMatching('/timeout'));
+    expect(logSpy).toHaveBeenCalledWith(expect.any(String), expect.stringMatching('GET /timeout'));
   });
 });

--- a/libs/utils/src/interceptors/timeout.interceptor.ts
+++ b/libs/utils/src/interceptors/timeout.interceptor.ts
@@ -44,8 +44,11 @@ export class TimeoutInterceptor implements NestInterceptor {
       timeout(this.timeoutMs),
       catchError((err) => {
         if (err instanceof TimeoutError) {
-          const route = context.switchToHttp().getRequest<Request>().url;
-          this.logger.error(`Request took longer than ${this.timeoutMs}ms to process; throwing timeout error`, route);
+          const request = context.switchToHttp().getRequest<Request>();
+          this.logger.error(
+            `Request took longer than ${this.timeoutMs}ms to process; throwing timeout error`,
+            `${request.method} ${request.url}`,
+          );
           return throwError(() => new RequestTimeoutException());
         }
         return throwError(() => err);


### PR DESCRIPTION
# Description
This PR adds logging the failed route when a timeout error occurs.

## Example
```
[Nest] 43834  - 03/31/2025, 11:06:59 AM   ERROR [GET /sampleRoute] Request took longer than 1000ms to process; throwing timeout error
```

Related issue #768 
Closes #770 