### PR TITLE
Fix/account load test issues

### DIFF
--- a/apps/account-api/src/controllers/v2/accounts-v2.controller.ts
+++ b/apps/account-api/src/controllers/v2/accounts-v2.controller.ts
@@ -100,7 +100,7 @@ export class AccountsControllerV2 {
     const payload = await this.siwfV2Service.getPayload(callbackRequest);
 
     // Validate claim handle transactions to prevent invalid submissions to the blockchain
-    await Promise.all(
+    const handleResults = await Promise.all(
       payload.payloads
         .filter((transaction) => isPayloadClaimHandle(transaction))
         .map(async (claimHandle) => {
@@ -110,6 +110,9 @@ export class AccountsControllerV2 {
           }
         }),
     );
+    if (handleResults.length) {
+      this.logger.debug(`Validated handles (${payload.userPublicKey.encodedValue})`);
+    }
 
     if (hasChainSubmissions(payload) && this.chainConfig.isDeployedReadOnly) {
       throw new ForbiddenException('New account sign-up unavailable in read-only mode');

--- a/apps/account-api/src/services/siwfV2.service.ts
+++ b/apps/account-api/src/services/siwfV2.service.ts
@@ -133,6 +133,7 @@ export class SiwfV2Service {
       try {
         // Await here so the error is caught
         payload = await validateSiwfResponse(request.authorizationPayload, loginMsgURIValidation);
+        this.logger.debug('Validated payload');
       } catch (e) {
         this.logger.warn('Failed to parse "authorizationPayload"', { error: e.toString() });
         throw new BadRequestException('Invalid `authorizationPayload` in request.');
@@ -144,6 +145,7 @@ export class SiwfV2Service {
           endpoint: this.swifV2Endpoint(),
           loginMsgUri: loginMsgURIValidation,
         });
+        this.logger.debug('Retrieved payload from SIWFv2');
       } catch (e) {
         this.logger.warn('Failed to retrieve valid payload from "authorizationCode"', { error: e.toString() });
         throw new BadRequestException('Invalid response from `authorizationCode` payload fetch.');
@@ -173,16 +175,19 @@ export class SiwfV2Service {
       }
     }
 
+    this.logger.verbose(`Payload: ${JSON.stringify(payload)}`);
     return payload;
   }
 
   async getSiwfV2LoginResponse(payload: SiwfResponse): Promise<WalletV2LoginResponseDto> {
+    this.logger.debug('Generating login response');
     const response = new WalletV2LoginResponseDto();
 
     response.controlKey = payload.userPublicKey.encodedValue;
 
     // Get the MSA Id from the chain, if it exists
     const msaId = await this.blockchainService.publicKeyToMsaId(response.controlKey);
+    this.logger.debug(`Result of MSA check: ${msaId}`);
     if (msaId) response.msaId = msaId;
 
     // Parse out the email, phone, and graph

--- a/apps/account-api/src/services/siwfV2.service.ts
+++ b/apps/account-api/src/services/siwfV2.service.ts
@@ -133,7 +133,7 @@ export class SiwfV2Service {
       try {
         // Await here so the error is caught
         payload = await validateSiwfResponse(request.authorizationPayload, loginMsgURIValidation);
-        this.logger.debug('Validated payload');
+        this.logger.debug(`Validated payload (${payload.userPublicKey.encodedValue})`);
       } catch (e) {
         this.logger.warn('Failed to parse "authorizationPayload"', { error: e.toString() });
         throw new BadRequestException('Invalid `authorizationPayload` in request.');
@@ -145,7 +145,9 @@ export class SiwfV2Service {
           endpoint: this.swifV2Endpoint(),
           loginMsgUri: loginMsgURIValidation,
         });
-        this.logger.debug('Retrieved payload from SIWFv2');
+        this.logger.debug(
+          `Retrieved payload from SIWFv2 for authorizationCode '${request.authorizationCode}' (${payload.userPublicKey.encodedValue})`,
+        );
       } catch (e) {
         this.logger.warn('Failed to retrieve valid payload from "authorizationCode"', { error: e.toString() });
         throw new BadRequestException('Invalid response from `authorizationCode` payload fetch.');

--- a/apps/account-worker/src/transaction_publisher/publisher.service.ts
+++ b/apps/account-worker/src/transaction_publisher/publisher.service.ts
@@ -131,7 +131,8 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
           throw new Error(`Invalid job type.`);
         }
       }
-      this.logger.debug(`Successful job: ${JSON.stringify(job, null, 2)}`);
+      this.logger.debug(`Job successfully completed (${job.id})`);
+      this.logger.verbose(JSON.stringify(job, null, 2));
 
       const status: ITxStatus = {
         type: job.data.type,
@@ -207,7 +208,7 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
   processBatchTxn(
     callVec: Vec<Call> | (Call | IMethod | string | Uint8Array)[],
   ): ReturnType<BlockchainService['payWithCapacityBatchAll']> {
-    this.logger.debug(
+    this.logger.verbose(
       'processBatchTxn: callVec: ',
       callVec.map((c) => c.toHuman()),
     );

--- a/apps/account-worker/src/transaction_publisher/publisher.service.ts
+++ b/apps/account-worker/src/transaction_publisher/publisher.service.ts
@@ -36,7 +36,7 @@ const CAPACITY_EPOCH_TIMEOUT_NAME = 'capacity_check';
 export class TransactionPublisherService extends BaseConsumer implements OnApplicationBootstrap, OnApplicationShutdown {
   public async onApplicationBootstrap() {
     await this.capacityCheckerService.checkForSufficientCapacity();
-    this.worker.concurrency = this.accountWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 2;
+    this.worker.concurrency = this.accountWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 1;
   }
 
   public async onApplicationShutdown(_signal?: string | undefined): Promise<void> {

--- a/apps/account-worker/src/transaction_publisher/publisher.service.ts
+++ b/apps/account-worker/src/transaction_publisher/publisher.service.ts
@@ -7,7 +7,13 @@ import { SubmittableExtrinsic } from '@polkadot/api-base/types';
 import { IMethod, ISubmittableResult, Signer, SignerResult } from '@polkadot/types/types';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { BlockchainService } from '#blockchain/blockchain.service';
-import { ICapacityInfo, NonceConflictError } from '#blockchain/types';
+import {
+  BadSignatureError,
+  ICapacityInfo,
+  InsufficientBalanceError,
+  MortalityError,
+  NonceConflictError,
+} from '#blockchain/types';
 import { AccountQueues as QueueConstants } from '#types/constants/queue.constants';
 import { BaseConsumer } from '#consumer';
 import { TransactionData } from '#types/dtos/account';
@@ -140,13 +146,36 @@ export class TransactionPublisherService extends BaseConsumer implements OnAppli
       obj[txHash] = JSON.stringify(status);
       this.cacheManager.hset(TXN_WATCH_LIST_KEY, obj);
     } catch (error: any) {
-      if (error instanceof DelayedError) {
+      if (error instanceof DelayedError || TransactionPublisherService.shouldRetry(job, error)) {
         job.moveToDelayed(Date.now(), job.token);
       } else {
         this.logger.error('Unknown error encountered: ', error, error?.stack);
       }
       throw error;
     }
+  }
+
+  /**
+   * Determine if job should be returned to the queue for retries.
+   * (Default retry logic is "1"; ie only a single attempt. But some chain
+   * submission errors deserve a retry; however, we don't want to retry indefinitely,
+   * so we cap it at 4)
+   * @param job The current job
+   * @param err The error that was thrown
+   * @returns Whether the job should be retried
+   */
+  public static shouldRetry(job: Job<any>, err: Error): boolean {
+    if (
+      job.attemptsStarted < 4 &&
+      (err instanceof NonceConflictError ||
+        err instanceof BadSignatureError ||
+        err instanceof InsufficientBalanceError ||
+        err instanceof MortalityError)
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   /**

--- a/libs/account-lib/src/services/enqueue-request.service.ts
+++ b/libs/account-lib/src/services/enqueue-request.service.ts
@@ -55,7 +55,7 @@ export class EnqueueService {
     const job = await this.transactionPublishQueue.add(`Transaction Job - ${data.referenceId}`, data, {
       jobId: data.referenceId,
     });
-    this.logger.debug('Submitted payload to the queue');
+    this.logger.debug(`Submitted payload to the queue (${referenceId})`);
     const jobState = await job.getState();
     this.logger.log(`Job submitted or retrieved: ${job.id} ${jobState}`);
     this.logger.verbose(JSON.stringify(job));

--- a/libs/account-lib/src/services/enqueue-request.service.ts
+++ b/libs/account-lib/src/services/enqueue-request.service.ts
@@ -55,9 +55,10 @@ export class EnqueueService {
     const job = await this.transactionPublishQueue.add(`Transaction Job - ${data.referenceId}`, data, {
       jobId: data.referenceId,
     });
+    this.logger.debug('Submitted payload to the queue');
     const jobState = await job.getState();
-
-    this.logger.log('Job enqueued or retrieved: ', JSON.stringify(job));
+    this.logger.log(`Job submitted or retrieved: ${job.id} ${jobState}`);
+    this.logger.verbose(JSON.stringify(job));
     return {
       referenceId: data.referenceId,
       state: jobState,

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -33,8 +33,14 @@ import { InjectRedis } from '@songkeys/nestjs-redis';
 import { BlockchainRpcQueryService } from './blockchain-rpc-query.service';
 import { NonceConstants } from '#types/constants';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { DelayedError } from 'bullmq';
-import { NonceConflictError, RpcError, SIWFTxnValues } from './types';
+import {
+  BadSignatureError,
+  InsufficientBalanceError,
+  MortalityError,
+  NonceConflictError,
+  RpcError,
+  SIWFTxnValues,
+} from './types';
 import { BN } from '@polkadot/util';
 
 export const NONCE_SERVICE_REDIS_NAMESPACE = 'NonceService';
@@ -198,6 +204,30 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     }
   }
 
+  public static createError(err: any): any {
+    if (err?.name === 'RpcError') {
+      if (/Priority is too low/.test(err?.message)) {
+        return new NonceConflictError(err);
+      }
+
+      if (/Transaction has a bad signature/.test(err?.message)) {
+        return new BadSignatureError(err);
+      }
+
+      if (/Inability to pay some fees/.test(err?.message)) {
+        return new InsufficientBalanceError(err);
+      }
+
+      if (/Transaction has an ancient birth block/.test(err?.message)) {
+        return new MortalityError(err);
+      }
+
+      return new RpcError(err);
+    }
+
+    return err;
+  }
+
   /**
    * Submits a transaction to the blockchain, paying for it with the provider's capacity.
    * @param tx
@@ -207,10 +237,6 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     tx: Call | IMethod | string | Uint8Array,
   ): Promise<[SubmittableExtrinsic<'promise'>, HexString, number]> {
     const extrinsic = this.api.tx.frequencyTxPayment.payWithCapacity(tx);
-    const outOfCapacity = await this.checkTxCapacityLimit(this.config.providerId, extrinsic.toHex());
-    if (outOfCapacity) {
-      throw new DelayedError();
-    }
     const keys = new Keyring({ type: 'sr25519' }).createFromUri(this.config.providerSeedPhrase);
     const nonce = await this.reserveNextNonce();
     const block = await this.getBlockForSigning();
@@ -226,15 +252,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
       return [extrinsic, txHash.toHex(), block.number];
     } catch (err: any) {
       await this.unreserveNonce(nonce);
-      if (err?.name === 'RpcError') {
-        if (/Priority is too low/.test(err?.message)) {
-          throw new NonceConflictError(err);
-        }
-
-        throw new RpcError(err);
-      }
-
-      throw err;
+      throw BlockchainService.createError(err);
     }
   }
 
@@ -247,10 +265,6 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     tx: Vec<Call> | (Call | IMethod | string | Uint8Array)[],
   ): Promise<[SubmittableExtrinsic<'promise'>, HexString, number]> {
     const extrinsic = this.api.tx.frequencyTxPayment.payWithCapacityBatchAll(tx);
-    const outOfCapacity = await this.checkTxCapacityLimit(this.config.providerId, extrinsic.toHex());
-    if (outOfCapacity) {
-      throw new DelayedError();
-    }
     const keys = new Keyring({ type: 'sr25519' }).createFromUri(this.config.providerSeedPhrase);
     const nonce = await this.reserveNextNonce();
     const block = await this.getBlockForSigning();
@@ -266,15 +280,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
       return [extrinsic, txHash.toHex(), block.number];
     } catch (err: any) {
       await this.unreserveNonce(nonce);
-      if (err?.name === 'RpcError') {
-        if (/Priority is too low/.test(err?.message)) {
-          throw new NonceConflictError(err);
-        }
-
-        throw new RpcError(err);
-      }
-
-      throw err;
+      throw BlockchainService.createError(err);
     }
   }
 
@@ -297,8 +303,8 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     return nextNonce;
   }
 
-  public async unreserveNonce(nonce: number) {
-    await this.nonceRedis.del(getNonceKey(this.accountId, `${nonce}`));
+  public unreserveNonce(nonce: number) {
+    return this.nonceRedis.del(getNonceKey(this.accountId, `${nonce}`));
   }
 
   public createTxFromEncoded(encodedTx: any): SubmittableExtrinsic<'promise', ISubmittableResult> {

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -117,7 +117,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
       .set(
         'latestFinalizedHeader',
         JSON.stringify({
-          blockHash: latestFinalizedBlock.toHex(),
+          blockHash: latestFinalizedHeader.hash.toHex(),
           number: latestFinalizedHeader.number.toNumber(),
           parentHash: latestFinalizedHeader.parentHash.toHex(),
         }),

--- a/libs/blockchain/src/blockchain.service.ts
+++ b/libs/blockchain/src/blockchain.service.ts
@@ -326,7 +326,7 @@ export class BlockchainService extends BlockchainRpcQueryService implements OnAp
     const latestHeader = JSON.parse(latestHeaderStr) as IHeaderInfo;
     const finalizedHeader = JSON.parse(finalizedHeaderStr) as IHeaderInfo;
 
-    return latestHeader.number - finalizedHeader.number > MAX_FINALITY_LAG.toNumber() ? finalizedHeader : latestHeader;
+    return latestHeader.number - finalizedHeader.number > MAX_FINALITY_LAG.toNumber() ? latestHeader : finalizedHeader;
   }
 
   /**

--- a/libs/blockchain/src/types.ts
+++ b/libs/blockchain/src/types.ts
@@ -38,4 +38,6 @@ export interface ICapacityFeeDetails {
 
 export class RpcError extends Error {}
 export class NonceConflictError extends RpcError {}
-export class FutureNonceError extends RpcError {}
+export class BadSignatureError extends RpcError {}
+export class InsufficientBalanceError extends RpcError {}
+export class MortalityError extends RpcError {}


### PR DESCRIPTION
- Revert the transaction publish queue default concurrency to 1, until we do some more investigation
- Fix inverted signing block header logic
- Retry failed chain transactions up to 4 times for the following RPC errors:
    - bad signature (Invalid Transaction)
    - insufficient balance
    - nonce conflict
    - expired mortality
- Added some happy path logging to account-service for the SIWFv2 signup flow to aid in troubleshooting

Closes #774 