### PR TITLE
fix: remove redundant Quick Start entry from documentation summary

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,9 +6,8 @@
 ---
 
 - [Guides](./GettingStarted/README.md)
-    - [Quick Start](./GettingStarted/QuickStart.md)
-    - [Become a Provider](./GettingStarted/BecomeProvider.md)
-    - [Single Sign On](./GettingStarted/SSO.md)
+  - [Become a Provider](./GettingStarted/BecomeProvider.md)
+  - [Single Sign On](./GettingStarted/SSO.md)
 - [Fundamentals](./Fundamentals/README.md)
   - [Blockchain Basics](./Fundamentals/BlockchainBasics.md)
   - [Frequency Networks](./Fundamentals/Networks.md)


### PR DESCRIPTION
# Problem

mdbook v0.4.48 fails to parse docs.

# Solution

Remove duplicate link to `./GettingStarted/QuickStart.md` in `SUMMARY.md`

with @emresurmeli 

Closes #777 

