### PR TITLE
fix: temporarily bump Redis commandTimeout to 25s

### DIFF
--- a/libs/cache/src/cache.config.ts
+++ b/libs/cache/src/cache.config.ts
@@ -12,7 +12,7 @@ export interface ICacheConfig {
 type CacheValidationOptions = ICacheConfig & { redisUrl: string };
 
 const DEFAULT_REDIS_OPTIONS: RedisOptions = {
-  commandTimeout: 10_000,
+  commandTimeout: 25_000,
 };
 
 export default registerAs('cache', (): ICacheConfig => {


### PR DESCRIPTION
We ran into a problem where the BullMQ "delayed" queue can cause Bull to poll with a delay longer than the default 10s timeout for Redis commands, causing polls to throw "CommandTimeout" errors and delayed jobs to be stuck in the queue. This PR is a hotfix to increase the command timeout temporarily until a more correct solution can be determined.