### PR TITLE
fix: add troubleshooting commands for Docker service deployment

### DIFF
--- a/docs/src/Run/Deployment.md
+++ b/docs/src/Run/Deployment.md
@@ -201,6 +201,18 @@ docker ps
 docker logs <container-id>
 ```
 
+If a container fails to deploy, and there are no logs, you can use the following command to see the logs from the stack deployment:
+
+```bash
+docker service ps <service-name> --no-trunc
+```
+
+You can find still more information about the service by inspecting the container:
+
+```bash
+docker inspect <container-id>
+```
+
 ---
 
 ## Part 2: Deploying with Kubernetes


### PR DESCRIPTION
# Problem

During deployment with Docker Swarm, the containers failed to deploy, so there were no logs available from the container. Users need more information to fault isolate and fix the problem.

# Solution - Docs Update

- Add the `docker service ps <service-name> --no-trunc` command to the troubleshooting section so that users can get more information when containers fail to deploy and fail to log.

