### PR TITLE
Content publishing; DELETE /v1/content/:msaId deprecation and new POST /v2/content/:msaId/tombstones

### DIFF
--- a/apps/content-publishing-api/src/controllers/v1/content.controller.v1.ts
+++ b/apps/content-publishing-api/src/controllers/v1/content.controller.v1.ts
@@ -58,7 +58,10 @@ export class ContentControllerV1 {
   }
 
   @Delete(':msaId')
-  @ApiOperation({ summary: 'Delete DSNP Content for user [deprecated; use `POST /v2/asset/upload` instead]', deprecated: true })
+  @ApiOperation({
+    summary: 'Delete DSNP Content for user [deprecated; use `POST /v2/content/{msaId}/tombstones` instead]',
+    deprecated: true,
+  })
   @HttpCode(202)
   @ApiResponse({ status: '2XX', type: AnnouncementResponseDto })
   async delete(@Param() { msaId }: MsaIdDto, @Body() tombstoneDto: TombstoneDto): Promise<AnnouncementResponseDto> {

--- a/apps/content-publishing-api/src/controllers/v1/content.controller.v1.ts
+++ b/apps/content-publishing-api/src/controllers/v1/content.controller.v1.ts
@@ -58,7 +58,7 @@ export class ContentControllerV1 {
   }
 
   @Delete(':msaId')
-  @ApiOperation({ summary: 'Delete DSNP Content for user' })
+  @ApiOperation({ summary: 'Delete DSNP Content for user [deprecated; use `POST /v2/asset/upload` instead]', deprecated: true })
   @HttpCode(202)
   @ApiResponse({ status: '2XX', type: AnnouncementResponseDto })
   async delete(@Param() { msaId }: MsaIdDto, @Body() tombstoneDto: TombstoneDto): Promise<AnnouncementResponseDto> {

--- a/apps/content-publishing-api/src/controllers/v2/content.controller.v2.ts
+++ b/apps/content-publishing-api/src/controllers/v2/content.controller.v2.ts
@@ -77,7 +77,10 @@ export class ContentControllerV2 {
   @ApiOperation({ summary: 'Delete DSNP Content for user' })
   @HttpCode(202)
   @ApiResponse({ status: '2XX', type: AnnouncementResponseDto })
-  async delete(@Param() { msaId }: MsaIdDto, @Body() tombstoneDto: TombstoneDto): Promise<AnnouncementResponseDto> {
+  async postTombstone(
+    @Param() { msaId }: MsaIdDto,
+    @Body() tombstoneDto: TombstoneDto,
+  ): Promise<AnnouncementResponseDto> {
     return this.apiService.enqueueRequest(AnnouncementTypeName.TOMBSTONE, msaId, tombstoneDto);
   }
 }

--- a/apps/content-publishing-api/src/controllers/v2/content.controller.v2.ts
+++ b/apps/content-publishing-api/src/controllers/v2/content.controller.v2.ts
@@ -12,7 +12,8 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApiService } from '../../api.service';
-import { AnnouncementResponseDto, BatchFilesDto, OnChainContentDto } from '#types/dtos/content-publishing';
+import { AnnouncementResponseDto, BatchFilesDto, OnChainContentDto, TombstoneDto } from '#types/dtos/content-publishing';
+import { AnnouncementTypeName } from '#types/enums';
 import { BlockchainRpcQueryService } from '#blockchain/blockchain-rpc-query.service';
 import { MsaIdDto } from '#types/dtos/common';
 import apiConfig, { IContentPublishingApiConfig } from '#content-publishing-api/api.config';
@@ -70,5 +71,13 @@ export class ContentControllerV2 {
   async postBatches(@Body() batchContentDto: BatchFilesDto): Promise<AnnouncementResponseDto[]> {
     const promises = batchContentDto.batchFiles.map((batchFile) => this.apiService.enqueueBatchRequest(batchFile));
     return Promise.all(promises);
+  }
+
+  @Post(':msaId/tombstones')
+  @ApiOperation({ summary: 'Delete DSNP Content for user' })
+  @HttpCode(202)
+  @ApiResponse({ status: '2XX', type: AnnouncementResponseDto })
+  async delete(@Param() { msaId }: MsaIdDto, @Body() tombstoneDto: TombstoneDto): Promise<AnnouncementResponseDto> {
+    return this.apiService.enqueueRequest(AnnouncementTypeName.TOMBSTONE, msaId, tombstoneDto);
   }
 }

--- a/openapi-specs/content-publishing.openapi.json
+++ b/openapi-specs/content-publishing.openapi.json
@@ -244,7 +244,8 @@
       },
       "delete": {
         "operationId": "ContentControllerV1_delete",
-        "summary": "Delete DSNP Content for user",
+        "summary": "Delete DSNP Content for user [deprecated; use `POST /v2/content/{msaId}/tombstones` instead]",
+        "deprecated": true,
         "parameters": [
           {
             "name": "msaId",


### PR DESCRIPTION
Solving #756 

I've followed the deprecation pattern that was used in `/v1/asset/upload` however I was unsuccessful when testing the routes. Seems I wasn't able to setup my gateway properly locally, will continue to work on doing that but I'll drop the code here if someone wants to test it out on their end.

Still left to do:
1. Write tests
2. Generate API docs 

cc: @JoeCap08055 