### PR TITLE
Announce correct batch file size

### DIFF
--- a/apps/content-publishing-worker/src/batch_announcer/batch.announcer.ts
+++ b/apps/content-publishing-worker/src/batch_announcer/batch.announcer.ts
@@ -73,13 +73,13 @@ export class BatchAnnouncer {
     // Get previously uploaded file from IPFS
     this.logger.log(`Getting info from IPFS for ${batch.cid}`);
     try {
-      const { cid, size } = await this.ipfsService.getInfo(batch.cid);
-      this.logger.debug(`Got info from IPFS: cid=${cid}, size=${size}`);
+      const size = await this.ipfsService.contentLengthInLocalGateway(batch.cid);
+      this.logger.debug(`Got info from IPFS: size=${size}`);
 
       const response = {
         id: batch.cid,
         schemaId: batch.schemaId,
-        data: { cid: cid.toV1().toString(), payloadLength: size },
+        data: { cid: batch.cid.toV1().toString(), payloadLength: size },
       };
       this.logger.debug(`Created job to announce existing batch: ${JSON.stringify(response)}`);
       return response;

--- a/apps/content-publishing-worker/src/batch_announcer/batch.announcer.ts
+++ b/apps/content-publishing-worker/src/batch_announcer/batch.announcer.ts
@@ -79,7 +79,7 @@ export class BatchAnnouncer {
       const response = {
         id: batch.cid,
         schemaId: batch.schemaId,
-        data: { cid: batch.cid.toV1().toString(), payloadLength: size },
+        data: { cid: batch.cid, payloadLength: size },
       };
       this.logger.debug(`Created job to announce existing batch: ${JSON.stringify(response)}`);
       return response;

--- a/libs/storage/src/ipfs/ipfs.service.ts
+++ b/libs/storage/src/ipfs/ipfs.service.ts
@@ -79,9 +79,12 @@ export class IpfsService {
   }
 
   public async existsInLocalGateway(cid: string): Promise<boolean> {
-    return this.contentLengthInLocalGateway(cid)
-      .then(() => true)
-      .catch(() => false);
+    try {
+      await this.contentLengthInLocalGateway(cid);
+      return true;
+    } catch (_err) {
+      return false;
+    }
   }
 
   public async isPinned(cid: string): Promise<boolean> {

--- a/libs/storage/src/ipfs/ipfs.service.ts
+++ b/libs/storage/src/ipfs/ipfs.service.ts
@@ -60,26 +60,28 @@ export class IpfsService {
   }
 
   /**
-   * gets the true content-length of the CID file from the IPFS gateway
-   * if the file does not exist locally, returns -1
+   * gets the true content-length of the CID file from the IPFS gateway,
+   * or NaN if the content-length is unknown.
+   * if the file does not exist locally, or a network error occurs, throws an error
    */
   public async contentLengthInLocalGateway(cid: string): Promise<number> {
     this.logger.debug(`Requesting HEAD for ${cid}`);
     const response = await fetch(getIpfsCidPlaceholder(cid, this.gatewayUrl), {
-      method: "HEAD",
+      method: 'HEAD',
       headers: {
-        "Cache-Control": "only-if-cached",
+        'Cache-Control': 'only-if-cached',
       },
     });
-    if (response && response.status === 200) {
-      return Number(response.headers.get("Content-Length"));
-    } else {
-      return -1;
+    if (response?.status === 200) {
+      return Number(response.headers?.get('Content-Length'));
     }
+    throw new Error(`Unable to access HEAD for ${cid}`);
   }
 
   public async existsInLocalGateway(cid: string): Promise<boolean> {
-    return -1 !== (await this.contentLengthInLocalGateway(cid));
+    return this.contentLengthInLocalGateway(cid)
+      .then(() => true)
+      .catch(() => false);
   }
 
   public async isPinned(cid: string): Promise<boolean> {


### PR DESCRIPTION
# Problem

`ipfs.dag.stat` gives a `size` value that is not the same as the actual size of a file when downloaded.
This is because the DAG stores additional info beyond the raw file bytes.

An example can be seen in the difference between `dag.stat` and `files.stat`, where the actual length of the file is 87,699 bytes:

`dag.stat` reports the incorrect (for our purposes) value (twice, for good measure):

```
% curl -s -d '' '$IPFS_RPC_URL/api/v0/dag/stat?arg=bafybeibkvwtaugltazjt7oeq6xahz2qwvd5sm75twsht3e45niuxnfg654' | jq .
{
  "UniqueBlocks": 1,
  "TotalSize": 87713,
  "Ratio": 1,
  "DagStats": [
    {
      "Cid": "bafybeibkvwtaugltazjt7oeq6xahz2qwvd5sm75twsht3e45niuxnfg654",
      "Size": 87713,
      "NumBlocks": 1
    }
  ]
}
```

... whereas `files.stat` gives us both the file size and the DAG size:

```
% curl -s -d '' '$IPFS_RPC_URL/api/v0/files/stat?arg=/ipfs/bafybeibkvwtaugltazjt7oeq6xahz2qwvd5sm75twsht3e45niuxnfg654&progress=true' | jq .
{
  "Hash": "bafybeibkvwtaugltazjt7oeq6xahz2qwvd5sm75twsht3e45niuxnfg654",
  "Size": 87699,
  "CumulativeSize": 87713,
  "Blocks": 0,
  "Type": "file"
}
```

The correct value is also present in a `HEAD` request via the gateway:

```
% curl -s --head '$IPFS_GATEWAY_URL/ipfs/bafybeibkvwtaugltazjt7oeq6xahz2qwvd5sm75twsht3e45niuxnfg654' | grep Content-Length:
Content-Length: 87699
```

# Solution

Since we can get the correct size from the `Content-Length` header of the `HEAD /ipfs/[CID]` response, and we're already using this as an existence check, I modified the code to get size info from this request as well.

It has the nice side effect of one less request to the IPFS server.

The `ipfsService.getInfo(cid)` method has been removed since it was otherwise unused, and was not providing the output expected. The batch announcer has been updated to get the file size value directly via the new method, `ipfsService.contentLengthInLocalGateway(cid)`.

## Steps to Verify:

1. Check the `payload_length` reported in a Frequency IpfsMessage against the actual file size of the batch.
