### PR TITLE
fix: better file stream error handling

### DIFF
--- a/apps/content-publishing-api/src/api.service.ts
+++ b/apps/content-publishing-api/src/api.service.ts
@@ -309,6 +309,10 @@ export class ApiService {
     uploadPassThru.on('error', handleError);
     hashPassThru.on('error', handleError);
 
+    // Enable more logging
+    uploadPassThru.on('close', () => this.logger.verbose('uploadPassThru CLOSED'));
+    uploadPassThru.on('end', () => this.logger.verbose('uploadPassThru END'));
+
     stream.pipe(uploadPassThru);
     stream.pipe(hashPassThru);
 

--- a/apps/content-publishing-api/src/api.service.ts
+++ b/apps/content-publishing-api/src/api.service.ts
@@ -271,9 +271,43 @@ export class ApiService {
       return { error: `Unsupported file type (${mimetype})` };
     }
 
+    let errored = false;
+
     // Create pipes to process IPFS upload & DSNP multihash calculation in parallel
     const uploadPassThru = new PassThrough();
     const hashPassThru = new PassThrough();
+
+    // Stream error handler to make sure cleanup occurs on any stream error--
+    // but only ONCE
+    const handleError = (err: any) => {
+      if (errored) return;
+      errored = true;
+
+      this.logger.error('❌ Stream error:', err?.message || err);
+
+      // Try to destroy everything cleanly
+      [uploadPassThru, hashPassThru].forEach((s) => {
+        if (!s.destroyed) {
+          // If still readable, resume so request doesn’t hang
+          if (!s.readableEnded && !s.readableFlowing) {
+            s.removeAllListeners('readable');
+            s.resume();
+          }
+
+          // Then destroy (safe even if already ended)
+          s.destroy(err);
+        }
+      });
+
+      // Important: only destroy original stream after dependents
+      if (!stream.destroyed) {
+        stream.destroy(err);
+      }
+    };
+
+    stream.on('error', handleError);
+    uploadPassThru.on('error', handleError);
+    hashPassThru.on('error', handleError);
 
     stream.pipe(uploadPassThru);
     stream.pipe(hashPassThru);
@@ -287,12 +321,8 @@ export class ApiService {
         calculateIncrementalDsnpMultiHash(hashPassThru),
       ]);
     } catch (error: any) {
-      // Make sure streams are properly resumed so the main request can continue
-      // Streams will not resume properly unless there are NO 'readable' event handlers
-      uploadPassThru.removeAllListeners('readable');
-      hashPassThru.removeAllListeners('readable');
-      uploadPassThru.resume();
-      hashPassThru.resume();
+      this.logger.error('❌ Upload/hash promise error:', error.message);
+      handleError(error);
       return { error: error?.message || `Error uploading or hashing file ${filename}` };
     }
 


### PR DESCRIPTION
# Problem
`content-publishing-api` `POST /v2/asset/upload` endpoint has been experiencing unhandled file stream termination errors. Although we have been unable to reproduce locally to determine the root cause, code inspection reveals that we are not handling errors properly on the file streams.

This solution may not eliminate the errors & still result in assets that fail to upload; however, it should at least prevent the application from crashing, and possibly allow for some better data collection as a result.
