### PR TITLE
fix: get correct file size from IPFS, without hanging

### DIFF
--- a/apps/content-publishing-worker/src/batch_announcer/batch.announcer.ts
+++ b/apps/content-publishing-worker/src/batch_announcer/batch.announcer.ts
@@ -73,13 +73,13 @@ export class BatchAnnouncer {
     // Get previously uploaded file from IPFS
     this.logger.log(`Getting info from IPFS for ${batch.cid}`);
     try {
-      const size = await this.ipfsService.contentLengthInLocalGateway(batch.cid);
-      this.logger.debug(`Got info from IPFS: size=${size}`);
+      const { cid, size } = await this.ipfsService.getInfoFromLocalNode(batch.cid);
+      this.logger.debug(`Got info from IPFS: cid=${cid}, size=${size}`);
 
       const response = {
         id: batch.cid,
         schemaId: batch.schemaId,
-        data: { cid: batch.cid, payloadLength: size },
+        data: { cid: cid.toV1().toString(), payloadLength: size },
       };
       this.logger.debug(`Created job to announce existing batch: ${JSON.stringify(response)}`);
       return response;

--- a/libs/storage/src/ipfs/ipfs.service.ts
+++ b/libs/storage/src/ipfs/ipfs.service.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto';
 import { extension as getExtension } from 'mime-types';
 import { FilePin } from '#storage/ipfs/pin.interface';
 import { calculateDsnpMultiHash, calculateIncrementalDsnpMultiHash } from '#utils/common/common.utils';
-import { createKuboRPCClient, KuboRPCClient, CID } from 'kubo-rpc-client';
+import { createKuboRPCClient, KuboRPCClient, CID, FilesStatResult, FilesStatOptions } from 'kubo-rpc-client';
 import httpCommonConfig, { IHttpCommonConfig } from '#config/http-common.config';
 import { Readable } from 'stream';
 
@@ -59,12 +59,26 @@ export class IpfsService {
     return Buffer.concat(chunks);
   }
 
-  /**
-   * gets the true content-length of the CID file from the IPFS gateway,
-   * or NaN if the content-length is unknown.
-   * if the file does not exist locally, or a network error occurs, throws an error
-   */
-  public async contentLengthInLocalGateway(cid: string): Promise<number> {
+  public async getInfoFromLocalNode(cid: string): Promise<FilesStatResult> {
+    this.logger.debug(`Requesting IPFS stats for ${cid}`);
+    // Specify 'offline: true' to return immediately with an error
+    // if the file is not in the local node's cache.
+    // (The 'kubo-rpc-client' package doesn't include the 'offline' property,
+    // but it's one of the root Kubo CLI options that are all supported:
+    // https://docs.ipfs.tech/reference/kubo/cli/#ipfs
+    // Alternatively, could use the 'timeout' property to return an error
+    // after the specified timeout)
+    try {
+      const response = await this.ipfs.files.stat(CID.parse(cid), { offline: true } as FilesStatOptions);
+      this.logger.debug(`IPFS response: ${JSON.stringify(response)}`);
+      return response;
+    } catch (err: any) {
+      this.logger.error(err?.message || err);
+      throw new Error('Requested resource not found');
+    }
+  }
+
+  public async existsInLocalGateway(cid: string): Promise<boolean> {
     this.logger.debug(`Requesting HEAD for ${cid}`);
     const response = await fetch(getIpfsCidPlaceholder(cid, this.gatewayUrl), {
       method: 'HEAD',
@@ -72,19 +86,7 @@ export class IpfsService {
         'Cache-Control': 'only-if-cached',
       },
     });
-    if (response?.status === 200) {
-      return Number(response.headers?.get('Content-Length'));
-    }
-    throw new Error(`Unable to access HEAD for ${cid}`);
-  }
-
-  public async existsInLocalGateway(cid: string): Promise<boolean> {
-    try {
-      await this.contentLengthInLocalGateway(cid);
-      return true;
-    } catch (_err) {
-      return false;
-    }
+    return response && response.status === 200;
   }
 
   public async isPinned(cid: string): Promise<boolean> {


### PR DESCRIPTION
# Description
This PR restores the logic to get the file size of a file in IPFS using the Kubo RPC API, with the added logic to avoid hanging if the file is not cached in the local node.

Closes #832 