### PR TITLE
Fix issue with ipfs.files.stat

### DIFF
--- a/__mocks__/kubo-rpc-client.ts
+++ b/__mocks__/kubo-rpc-client.ts
@@ -27,7 +27,7 @@ export class CID {
   }
 }
 
-export interface BlockStatResult {
+export interface FilesStatResult {
   cid: string;
   size: number;
 }
@@ -40,8 +40,8 @@ export interface PinLsResult {
 }
 
 export interface KuboRPCClient {
-  block: {
-    stat: (cid: string) => Promise<BlockStatResult>;
+  files: {
+    stat: (path: string) => Promise<FilesStatResult>;
   };
   cat: (cid: string) => AsyncIterable<Uint8Array>;
   pin: {
@@ -53,8 +53,8 @@ export interface KuboRPCClient {
 
 export const createKuboRPCClient = jest.fn(
   (): KuboRPCClient => ({
-    block: {
-      stat: jest.fn(async (cid: string) => ({
+    files: {
+      stat: jest.fn(async (path: string) => ({
         cid,
         size: 1234,
         cumulativeSize: 5678,

--- a/libs/storage/src/ipfs/ipfs.service.spec.ts
+++ b/libs/storage/src/ipfs/ipfs.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { GenerateMockConfigProvider } from '#testlib/utils.config-tests';
 import { FilePin, IIpfsConfig, IpfsService } from '#storage';
 import { IHttpCommonConfig } from '#config/http-common.config';
-import { dummyCidV0, dummyCidV1, BlockStatResult, CID, KuboRPCClient, PinLsResult } from '__mocks__/kubo-rpc-client';
+import { dummyCidV0, dummyCidV1, FilesStatResult, CID, KuboRPCClient, PinLsResult } from '__mocks__/kubo-rpc-client';
 import { Readable } from 'stream';
 
 const mockIpfsConfigProvider = GenerateMockConfigProvider<IIpfsConfig>('ipfs', {
@@ -61,20 +61,19 @@ describe('IpfsService Tests', () => {
     });
   });
 
-  describe('getInfo', () => {
+  describe('getInfoFromLocalNode', () => {
     it('should throw if resource does not exist', async () => {
-      jest.spyOn(service, 'existsInLocalGateway').mockResolvedValueOnce(false);
-      await expect(service.getInfoFromLocalNode(dummyCidV1)).rejects.toThrow('Requested resource does not exist');
+      jest.spyOn(ipfs.files, 'stat').mockRejectedValueOnce('some error message');
+      await expect(service.getInfoFromLocalNode(dummyCidV1)).rejects.toThrow('Requested resource not found');
     });
 
     it('should return file info if it exists', async () => {
-      const fileInfo: BlockStatResult = {
+      const fileInfo: FilesStatResult = {
         cid: dummyCidV1,
         size: 1024,
       };
 
-      jest.spyOn(service, 'existsInLocalGateway').mockResolvedValueOnce(true);
-      jest.spyOn(ipfs.block, 'stat').mockResolvedValueOnce(fileInfo);
+      jest.spyOn(ipfs.files, 'stat').mockResolvedValueOnce(fileInfo);
 
       await expect(service.getInfoFromLocalNode(dummyCidV1)).resolves.toStrictEqual(fileInfo);
     });

--- a/libs/storage/src/ipfs/ipfs.service.ts
+++ b/libs/storage/src/ipfs/ipfs.service.ts
@@ -69,7 +69,7 @@ export class IpfsService {
     // Alternatively, could use the 'timeout' property to return an error
     // after the specified timeout)
     try {
-      const response = await this.ipfs.files.stat(CID.parse(cid), { offline: true } as FilesStatOptions);
+      const response = await this.ipfs.files.stat(`/ipfs/${CID.parse(cid)}`, { offline: true } as FilesStatOptions);
       this.logger.debug(`IPFS response: ${JSON.stringify(response)}`);
       return response;
     } catch (err: any) {


### PR DESCRIPTION
# Problem

`ipfs.files.stat` was always returning an error: `paths must start with a leading slash` instead of a `FilesStatResult`.

In addition, the tests weren't correctly mocking `ipfs.files.stat` (they were still referencing `ipfs.block.stat`).

# Solution

Pass ipfs.files.stat a path, not a CID.

Also correct mocks and tests.

## Steps to Verify:

See if batches get announced successfully.