### PR TITLE
Revert the redis.config file

### DIFF
--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -90,16 +90,17 @@
 # will only be able to accept client connections from the same host that it is
 # running on).
 #
-# IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
-# COMMENT OUT THE FOLLOWING LINE.
+# IF YOU DO NOT WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
+# COMMENT OUT THE FOLLOWING LINE AND use 
+bind * -::*
 #
-# bind * -::*
+# We recommend binding to the loopback interface only, simply comment out
+# the following line.
+# bind 127.0.0.1
 #
 # You will also need to set a password unless you explicitly disable protected
 # mode.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# We recommend binding to the loopback interface only.
-bind 127.0.0.1
 
 # By default, outgoing connections (from replica to master, from Sentinel to
 # instances, cluster bus, etc.) are not bound to a specific local address. In
@@ -2289,35 +2290,3 @@ jemalloc-bg-thread yes
 # to suppress
 #
 # ignore-warnings ARM64-COW-BUG
-
-################################# PERSISTENCE #################################
-
-# Enable AOF persistence (required for Gateway Services)
-appendonly yes
-
-# Sync strategy: 'everysec' provides a good balance between performance and durability
-appendfsync everysec
-
-# Base AOF filename
-appendfilename "appendonly.aof"
-
-# Directory where AOF files will be stored
-appenddirname "appenddir"
-
-# Auto-rewrite settings
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 64mb
-
-# Prevent fsync() during rewrites to avoid latency spikes
-no-appendfsync-on-rewrite no
-
-############################## MEMORY MANAGEMENT ################################
-
-# Set a memory usage limit (adjust based on your environment)
-maxmemory 2gb
-
-# Choose an eviction policy (recommended for Gateway Services)
-maxmemory-policy volatile-lru
-
-# Tune sample size for LRU algorithm
-maxmemory-samples 5


### PR DESCRIPTION
New configs are messing up tests - revert to previous version