### PR TITLE
pino logging for content-watcher. Two remaining provider initializations in modules.

### DIFF
--- a/apps/account-worker/src/main.ts
+++ b/apps/account-worker/src/main.ts
@@ -36,7 +36,7 @@ async function bootstrap() {
     strategy: new KeepAliveStrategy(),
   });
   app.useLogger(app.get(PinoLogger));
-  logger.info('Nest ApplicationContext created successfully.');
+  logger.info('Nest ApplicationContext for Account Worker created.');
 
   // Get event emitter & register a shutdown listener
   const eventEmitter = app.get<EventEmitter2>(EventEmitter2);

--- a/apps/content-publishing-worker/src/worker.module.ts
+++ b/apps/content-publishing-worker/src/worker.module.ts
@@ -19,6 +19,8 @@ import { QueueModule } from '#queue/queue.module';
 import { NONCE_SERVICE_REDIS_NAMESPACE } from '#blockchain/blockchain.service';
 import { IpfsService } from '#storage';
 import httpCommonConfig from '#config/http-common.config';
+import { LoggerModule } from 'nestjs-pino';
+import { getPinoHttpOptions } from '#logger-lib';
 
 @Module({
   imports: [
@@ -60,6 +62,7 @@ import httpCommonConfig from '#config/http-common.config';
       // disable throwing uncaughtException if an error event is emitted and it has no listeners
       ignoreErrors: false,
     }),
+    LoggerModule.forRoot(getPinoHttpOptions()),
     ScheduleModule.forRoot(),
     PublisherModule,
     BatchAnnouncerModule,

--- a/apps/content-watcher/src/api.module.ts
+++ b/apps/content-watcher/src/api.module.ts
@@ -21,6 +21,8 @@ import { PubSubModule } from '#content-watcher/pubsub/pubsub.module';
 import { CrawlerModule } from '#content-watcher/crawler/crawler.module';
 import { IPFSProcessorModule } from '#content-watcher/ipfs/ipfs.processor.module';
 import httpCommonConfig from '#config/http-common.config';
+import { LoggerModule } from 'nestjs-pino';
+import { getPinoHttpOptions } from '#logger-lib';
 
 @Module({
   imports: [
@@ -48,6 +50,7 @@ import httpCommonConfig from '#config/http-common.config';
       useFactory: (conf: ICacheConfig) => [{ ...conf.redisOptions, keyPrefix: conf.cacheKeyPrefix }],
       inject: [cacheConfig.KEY],
     }),
+    LoggerModule.forRoot(getPinoHttpOptions()),
     QueueModule.forRoot({ enableUI: true, ...QueueConstants.CONFIGURED_QUEUES }),
     EventEmitterModule.forRoot({
       // Use this instance throughout the application

--- a/apps/content-watcher/src/api.service.ts
+++ b/apps/content-watcher/src/api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRedis } from '@songkeys/nestjs-redis';
 import Redis from 'ioredis';
 import { InjectQueue } from '@nestjs/bullmq';
@@ -16,6 +16,8 @@ import { IWebhookRegistration } from '#types/dtos/content-watcher/subscription.w
 import { IScanReset } from '#types/interfaces/content-watcher/scan-reset.interface';
 import { IAnnouncementSubscription } from '#types/interfaces/content-watcher/announcement-subscription.interface';
 import { ContentSearchRequestDto } from '#types/dtos/content-watcher';
+import { Logger, pino } from 'pino';
+import { getBasicPinoOptions } from '#logger-lib';
 
 @Injectable()
 export class ApiService {
@@ -26,7 +28,7 @@ export class ApiService {
     @InjectQueue(QueueConstants.WATCHER_REQUEST_QUEUE_NAME) private requestQueue: Queue,
     private readonly scannerService: ScannerService,
   ) {
-    this.logger = new Logger(this.constructor.name);
+    this.logger = pino(getBasicPinoOptions(this.constructor.name));
   }
 
   public async getWatchOptions(): Promise<ChainWatchOptionsDto | null> {

--- a/apps/content-watcher/src/controllers/v1/scanner.controller.ts
+++ b/apps/content-watcher/src/controllers/v1/scanner.controller.ts
@@ -1,17 +1,17 @@
-import { Body, Controller, Get, Logger, NotFoundException, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, NotFoundException, Post, Query } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ApiService } from '#content-watcher/api.service';
 import { ResetScannerDto } from '#types/dtos/content-watcher';
 import { ChainWatchOptionsDto } from '#types/dtos/content-watcher/chain.watch.dto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 
 @Controller({ version: '1', path: 'scanner' })
 @ApiTags('v1/scanner')
 export class ScanControllerV1 {
-  private readonly logger: Logger;
-
-  constructor(private apiService: ApiService) {
-    this.logger = new Logger(this.constructor.name);
-  }
+  constructor(
+    private apiService: ApiService,
+    @InjectPinoLogger(ScanControllerV1.name) private readonly logger: PinoLogger,
+  ) {}
 
   @Post('reset')
   @ApiOperation({ summary: 'Reset blockchain scan to a specific block number or offset from the current position' })

--- a/apps/content-watcher/src/controllers/v1/webhooks.controller.ts
+++ b/apps/content-watcher/src/controllers/v1/webhooks.controller.ts
@@ -3,17 +3,17 @@ import {
   WebhookRegistrationDto,
   WebhookRegistrationResponseDto,
 } from '#types/dtos/content-watcher/subscription.webhook.dto';
-import { Body, Controller, Delete, Get, HttpStatus, Logger, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpStatus, Post } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 
 @Controller({ version: '1', path: 'webhooks' })
 @ApiTags('v1/webhooks')
 export class WebhookControllerV1 {
-  private readonly logger: Logger;
-
-  constructor(private apiService: ApiService) {
-    this.logger = new Logger(this.constructor.name);
-  }
+  constructor(
+    private apiService: ApiService,
+    @InjectPinoLogger(WebhookRegistrationDto.name) private readonly logger: PinoLogger,
+  ) {}
 
   @Post()
   @ApiOperation({ summary: 'Register a webhook to be called when new content is encountered on the chain' })

--- a/apps/content-watcher/src/main.ts
+++ b/apps/content-watcher/src/main.ts
@@ -6,8 +6,9 @@ import apiConfig, { IContentWatcherApiConfig } from './api.config';
 import { TimeoutInterceptor } from '#utils/interceptors/timeout.interceptor';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { generateSwaggerDoc, initializeSwaggerUI, writeOpenApiFile } from '#openapi/openapi';
-import { getBasicPinoOptions, getLogLevels } from '#logger-lib';
+import { getBasicPinoOptions } from '#logger-lib';
 import { pino } from 'pino';
+import { Logger as PinoLogger } from 'nestjs-pino';
 
 const logger = pino(getBasicPinoOptions('content-watcher.main'));
 
@@ -29,9 +30,9 @@ function startShutdownTimer() {
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(ApiModule, {
-    logger: getLogLevels(),
     rawBody: true,
   });
+  app.useLogger(app.get(PinoLogger));
 
   // Enable URL-based API versioning
   app.enableVersioning({
@@ -84,7 +85,6 @@ async function bootstrap() {
 
     initializeSwaggerUI(app, swaggerDoc);
     logger.info(`Listening on port ${config.apiPort}`);
-    logger.info(`Log levels: ${getLogLevels().join(', ')}`);
     await app.listen(config.apiPort);
   } catch (e) {
     await app.close();

--- a/apps/graph-worker/src/main.ts
+++ b/apps/graph-worker/src/main.ts
@@ -30,6 +30,7 @@ async function bootstrap() {
     strategy: new KeepAliveStrategy(),
   });
   app.useLogger(app.get(PinoLogger));
+  logger.info('Nest ApplicationContext for Graph Worker created.');
 
   // Get event emitter & register a shutdown listener
   const eventEmitter = app.get<EventEmitter2>(EventEmitter2);

--- a/apps/graph-worker/src/request_processor/request.processor.service.ts
+++ b/apps/graph-worker/src/request_processor/request.processor.service.ts
@@ -151,7 +151,7 @@ export class RequestProcessorService extends BaseConsumer implements OnApplicati
   ): Promise<Action[]> {
     const dsnpKeys: DsnpKeys = await this.graphStateManager.formDsnpKeys(dsnpUserId);
     const actions: Action[] = [];
-    // this.logger.debug(`Graph connections for user ${dsnpUserId.toString()}: ${JSON.stringify(graphConnections)}`);
+    this.logger.trace(`Graph connections for user ${dsnpUserId.toString()}: ${JSON.stringify(graphConnections)}`);
     // Import DSNP public graph keys for connected users in private friendship connections
     await this.importConnectionKeys(graphConnections);
     await Promise.all(

--- a/apps/graph-worker/src/worker.module.ts
+++ b/apps/graph-worker/src/worker.module.ts
@@ -17,6 +17,8 @@ import graphCommonConfig from '#config/graph-common.config';
 import { QueueModule } from '#queue/queue.module';
 import { NONCE_SERVICE_REDIS_NAMESPACE } from '#blockchain/blockchain.service';
 import httpCommonConfig from '#config/http-common.config';
+import { LoggerModule } from 'nestjs-pino';
+import { getPinoHttpOptions } from '#logger-lib';
 
 @Module({
   imports: [
@@ -57,6 +59,7 @@ import httpCommonConfig from '#config/http-common.config';
       ],
       inject: [cacheConfig.KEY, blockchainConfig.KEY],
     }),
+    LoggerModule.forRoot(getPinoHttpOptions()),
     ScheduleModule.forRoot(),
     BlockchainModule.forRootAsync(),
     RequestProcessorModule,

--- a/libs/graph-lib/src/utils/blockchain-scanner.service.spec.ts
+++ b/libs/graph-lib/src/utils/blockchain-scanner.service.spec.ts
@@ -11,6 +11,8 @@ import { IBlockchainNonProviderConfig } from '#blockchain/blockchain.config';
 import { GenerateMockConfigProvider } from '#testlib/utils.config-tests';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { AnyNumber } from '@polkadot/types/types';
+import { pino } from 'pino';
+import { getBasicPinoOptions } from '#logger-lib';
 
 jest.mock('@polkadot/api', () => {
   const originalModule = jest.requireActual<typeof import('@polkadot/api')>('@polkadot/api');
@@ -59,8 +61,9 @@ const mockEmptyBlockHash = {
 @Injectable()
 class ScannerService extends BlockchainScannerService {
   constructor(@InjectRedis() redis: Redis, blockchainService: BlockchainRpcQueryService) {
-    super(redis, blockchainService, new Logger('ScannerService'));
+    super(redis, blockchainService, pino(getBasicPinoOptions('ScannerService')));
   }
+
   // eslint-disable-next-line
   protected processCurrentBlock = jest.fn((_currentBlock: SignedBlock, _blockEvents: FrameSystemEventRecord[]) => {
     return Promise.resolve();

--- a/libs/graph-lib/src/utils/blockchain-scanner.service.ts
+++ b/libs/graph-lib/src/utils/blockchain-scanner.service.ts
@@ -5,7 +5,7 @@ import { BlockHash, SignedBlock } from '@polkadot/types/interfaces';
 import { BlockchainRpcQueryService } from '#blockchain/blockchain-rpc-query.service';
 import Redis from 'ioredis';
 import { FrameSystemEventRecord } from '@polkadot/types/lookup';
-import { Logger } from 'pino';
+import { Logger as PinoLogger } from 'pino';
 
 export const LAST_SEEN_BLOCK_NUMBER_KEY = 'lastSeenBlockNumber';
 
@@ -38,7 +38,7 @@ export abstract class BlockchainScannerService {
   constructor(
     protected cacheManager: Redis,
     protected readonly blockchainService: BlockchainRpcQueryService,
-    protected readonly logger: Logger,
+    protected readonly logger: PinoLogger,
   ) {
     this.lastSeenBlockNumberKey = `${this.constructor.name}:${LAST_SEEN_BLOCK_NUMBER_KEY}`;
     this.blockchainService.on('chain.disconnected', () => {

--- a/libs/logger/src/logLevel-common-config.ts
+++ b/libs/logger/src/logLevel-common-config.ts
@@ -1,21 +1,3 @@
-import { LogLevel } from '@nestjs/common';
-
-/**
- * Determines appropriate log levels based on environment variables
- * - Always includes 'error', 'warn', and 'log'
- * - Adds 'debug' when DEBUG env var is present
- * - Adds 'verbose' when VERBOSE_LOGGING is true or DEBUG=verbose
- */
-export function getLogLevels(): LogLevel[] {
-  const logLevels: LogLevel[] = ['error', 'warn', 'log'];
-
-  // Enable debug logging if DEBUG is set
-  if (process.env.DEBUG) {
-    logLevels.push('debug');
-  }
-  return logLevels;
-}
-
 export function getCurrentLogLevel(): string {
   let level: string = 'info';
   if (process.env?.LOG_LEVEL && process.env.LOG_LEVEL !== '') {


### PR DESCRIPTION
# Problem
Part of #477 , this is the content-watcher portion.

Also, two provider initializations were missing, one in graph-worker and one in content-publisher-worker.

## Steps to Verify:
1. run ./start.sh
2. in Docker dashboard, click to see the logs for each of the following and verify that they all start (or can be started) and don't error out due to a failure of the loggers:
    - account-api
    - account-worker
    - content-publishing-api
    - content-publishing-worker
    - content-watcher   
    - graph-api
    - graph-worker

You can optionally copy the environment files and set `PRETTY=false` to verify that all of these switch to JSON output.
