### PR TITLE
Feat/blockinfo endpoint

### DIFF
--- a/apps/account-api/src/api.module.ts
+++ b/apps/account-api/src/api.module.ts
@@ -4,6 +4,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
 import { LoggerModule } from 'nestjs-pino';
 import { BlockchainModule } from '#blockchain/blockchain.module';
+import { BlockInfoController } from '#blockchain/blockinfo.controller';
 import { EnqueueService } from '#account-lib/services/enqueue-request.service';
 import { AccountQueues as QueueConstants } from '#types/constants/queue.constants';
 import { CacheModule } from '#cache/cache.module';
@@ -89,6 +90,7 @@ import { createPrometheusConfig, getPinoHttpOptions } from '#logger-lib';
     HandlesControllerV1,
     KeysControllerV1,
     HealthController,
+    BlockInfoController,
   ],
   exports: [],
 })

--- a/apps/account-api/test/app.e2e-spec.ts
+++ b/apps/account-api/test/app.e2e-spec.ts
@@ -68,4 +68,21 @@ describe('Account Service E2E request verification!', () => {
     request(httpServer).get('/readyz').expect(200).expect({ status: 200, message: 'Service is ready' }));
 
   it('(GET) /metrics', () => request(httpServer).get('/metrics').expect(200));
+
+  it('GET /v1/frequency/blockinfo returns block info', async () => {
+    const res = await request(app.getHttpServer()).get('/blockchain/block-info').expect(200);
+
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        status: 200,
+        message: 'Block information retrieved successfully',
+        data: expect.objectContaining({
+          blocknumber: expect.any(Number),
+          finalized_blocknumber: expect.any(Number),
+          genesis: expect.any(String),
+          runtime_version: expect.anything(), // could be string or number depending on your API
+        }),
+      }),
+    );
+  });
 });

--- a/apps/graph-api/src/api.module.ts
+++ b/apps/graph-api/src/api.module.ts
@@ -7,6 +7,7 @@ import { ApiService } from './api.service';
 import { GraphQueues as QueueConstants } from '#types/constants/queue.constants';
 import { WebhooksControllerV1 } from './controllers/v1/webhooks-v1.controller';
 import { BlockchainModule } from '#blockchain/blockchain.module';
+import { BlockInfoController } from '#blockchain/blockinfo.controller';
 import { GraphStateManager } from '#graph-lib/services/graph-state-manager';
 import { CacheModule } from '#cache/cache.module';
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
@@ -75,7 +76,12 @@ import { createPrometheusConfig, getPinoHttpOptions } from '#logger-lib';
       useClass: AllExceptionsFilter,
     },
   ],
-  controllers: [GraphControllerV1, WebhooksControllerV1, HealthController],
+  controllers: [
+    GraphControllerV1,
+    WebhooksControllerV1,
+    HealthController,
+    BlockInfoController,
+  ],
   exports: [],
 })
 export class ApiModule {}

--- a/libs/blockchain/src/blockchain-rpc-query.service.ts
+++ b/libs/blockchain/src/blockchain-rpc-query.service.ts
@@ -177,6 +177,15 @@ export class BlockchainRpcQueryService extends PolkadotApiService {
     return undefined;
   }
 
+  public async getCurrentBlockInfo() {
+    return {
+      blockNumber: await this.getLatestBlockNumber(),
+      finalized_blocknumber: await this.getLatestBlockNumber(true),
+      genesis: (await this.api.rpc.chain.getBlockHash(0)).toHex(),
+      runtime_version: (await this.api.rpc.state.getRuntimeVersion()).specVersion.toNumber(),
+    };
+  }
+
   /**
    * Validates a given handle by querying the blockchain.
    *

--- a/libs/blockchain/src/blockinfo.controller.ts
+++ b/libs/blockchain/src/blockinfo.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { BlockchainRpcQueryService } from '#blockchain/blockchain-rpc-query.service';
+
+@Controller({ version: '1', path: 'frequency' })
+@ApiTags('/v1/frequency')
+export class BlockInfoController {
+  constructor(private blockchainService: BlockchainRpcQueryService) {}
+
+  // BlockInfo endpoint
+  // eslint-disable-next-line class-methods-use-this
+  @Get('blockinfo')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get information about current block' })
+  @ApiOkResponse({ description: 'Block information retrieved successfully' })
+  async blockInfo() {
+    return {
+      status: HttpStatus.OK,
+      message: 'Block information retrieved successfully',
+      data: await this.blockchainService.getCurrentBlockInfo(),
+    };
+  }
+}


### PR DESCRIPTION
# Problem
Tackling #867

# Solution
This draft implements an endpoint in the blockchain module that allows us to get blockinfo at `/v1/frequency/blockinfo`

# Further points

1. Should we make this controller a part of the api services? ie account and graph each get their own `blockinfo-v1.controller.ts` rather than a shared one in the `/blokchain` folder
2. Potential naming convention changes:
    - Route: `/v1/frequency/block-info`
    - Controller: `chain-info.controller.ts` (we can add more chain related endpoints exposing a lot of the RPC calls through Gateway)
    - Potentially make this its own API called frequency-api which is geared toward exposing chain info. Because this controller being a part of the account-api and graph-api isn't very RESTful?
    
    