### PR TITLE
Use the user id instead of user name so k8s can pick it up as non-root

### DIFF
--- a/Docker/Dockerfile.account
+++ b/Docker/Dockerfile.account
@@ -52,7 +52,7 @@ RUN chown -R gateway:nodejs /app && \
     mkdir ./openapi-specs && \
     apk add --no-cache jq curl tini libc6-compat
 
-USER gateway
+USER 1001
 
 EXPOSE 3000
 

--- a/Docker/Dockerfile.content-publishing
+++ b/Docker/Dockerfile.content-publishing
@@ -52,7 +52,7 @@ RUN chown -R gateway:nodejs /app && \
     mkdir ./openapi-specs && \
     apk add --no-cache jq curl tini libc6-compat
 
-USER gateway
+USER 1001
 
 EXPOSE 3000
 

--- a/Docker/Dockerfile.content-watcher
+++ b/Docker/Dockerfile.content-watcher
@@ -45,7 +45,7 @@ RUN chown -R gateway:nodejs /app && \
     mkdir ./openapi-specs && \
     apk add --no-cache jq curl tini libc6-compat
 
-USER gateway
+USER 1001
 
 EXPOSE 3000
 

--- a/Docker/Dockerfile.dev
+++ b/Docker/Dockerfile.dev
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S gateway -u 1001 -G nodejs
 
-USER gateway
+USER 1001
 
 EXPOSE 3000
 

--- a/Docker/Dockerfile.graph
+++ b/Docker/Dockerfile.graph
@@ -52,7 +52,7 @@ RUN chown -R gateway:nodejs /app && \
     mkdir ./openapi-specs && \
     apk add --no-cache jq curl tini libc6-compat
 
-USER gateway
+USER 1001
 
 EXPOSE 3000
 


### PR DESCRIPTION
# Problem

`USER gateway` is not enough for k8s and it will still throw:

```
Error: container has runAsNonRoot and image has non-numeric user (gateway), cannot verify user is non-root (pod: "...", container: account-service-api)
```

# Solution

Switch to `USER 1001` the hard coded user id