### PR TITLE
fix: adjust docker user creation commands, dev container permissions

### DIFF
--- a/Docker/Dockerfile.account
+++ b/Docker/Dockerfile.account
@@ -34,8 +34,8 @@ FROM node:22-alpine
 ENV NODE_ENV=production
 
 # Create a non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S gateway -u 1001 -G nodejs
+RUN addgroup -g 1001 nodejs && \
+    adduser -u 1001 -G nodejs -s /bin/sh -D gateway
 
 WORKDIR /app
 

--- a/Docker/Dockerfile.content-publishing
+++ b/Docker/Dockerfile.content-publishing
@@ -34,8 +34,8 @@ FROM node:22-alpine
 ENV NODE_ENV=production
 
 # Create a non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S gateway -u 1001 -G nodejs
+RUN addgroup -g 1001 nodejs && \
+    adduser -u 1001 -G nodejs -s /bin/sh -D gateway
 
 WORKDIR /app
 

--- a/Docker/Dockerfile.content-watcher
+++ b/Docker/Dockerfile.content-watcher
@@ -30,8 +30,8 @@ FROM node:22-alpine
 ENV NODE_ENV=production
 
 # Create a non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S gateway -u 1001 -G nodejs
+RUN addgroup -g 1001 nodejs && \
+    adduser -u 1001 -G nodejs -s /bin/sh -D gateway
 
 WORKDIR /app
 

--- a/Docker/Dockerfile.dev
+++ b/Docker/Dockerfile.dev
@@ -3,8 +3,15 @@ FROM node:22
 WORKDIR /app
 
 # Create a non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S gateway -u 1001 -G nodejs
+RUN groupadd -g 1001 nodejs && \
+    useradd -u 1001 -g nodejs -s /bin/bash -m gateway
+
+RUN mkdir -p /app/node_modules && \
+    chown -R gateway:nodejs /app && \
+    chmod -R 775 /app
+
+RUN echo "umask 002" >> /home/gateway/.bashrc && \
+    echo "umask 002" >> /etc/profile
 
 USER 1001
 

--- a/Docker/Dockerfile.graph
+++ b/Docker/Dockerfile.graph
@@ -34,8 +34,8 @@ FROM node:22-alpine
 ENV NODE_ENV=production
 
 # Create a non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S gateway -u 1001 -G nodejs
+RUN addgroup -g 1001 nodejs && \
+    adduser -u 1001 -G nodejs -s /bin/sh -D gateway
 
 WORKDIR /app
 


### PR DESCRIPTION
# Problem

Unable to run local Gateway containers to test code due to permissions issues.

`npm error code EACCES

npm error syscall mkdir

npm error path /app/node_modules/@0no-co

npm error errno -13

npm error Error: EACCES: permission denied, mkdir '/app/node_modules/@0no-co'` 

problem statement, including
Link to GitHub Issue(s): [#887](https://github.com/ProjectLibertyLabs/gateway/issues/887)

# Solution

Confirm docker user/group command syntax, pre-create node_modules and grant write access to avoid permission issues in docker volumes.

with @shannonwells 

## Steps to Verify:

1. ./start.sh with 'n' option for use the published Gateway Services containers.

Removal of existing containers/volumes helped with testing with a clean state, but made the build process rather long.

`docker builder prune -af`
`docker rmi gateway-dev:latest 2>/dev/null || true`

## Screenshots (optional):

<img width="1659" height="969" alt="Screenshot 2025-07-18 at 12 27 10 PM" src="https://github.com/user-attachments/assets/58eacfb9-3462-4ce1-ace5-71a26c8b45d5" />

