### PR TITLE
fix: make SWIF_NODE_RPC_URL env var optional

### DIFF
--- a/apps/account-api/src/api.config.spec.ts
+++ b/apps/account-api/src/api.config.spec.ts
@@ -25,8 +25,6 @@ describe('Account API Config', () => {
   });
 
   describe('invalid environment', () => {
-    it('missing SIWF Node RPC url should fail', async () => validateMissing(ALL_ENV, 'SIWF_NODE_RPC_URL'));
-
     it('invalid SIWF Node RPC url should fail', async () =>
       shouldFailBadValues(ALL_ENV, 'SIWF_NODE_RPC_URL', ['invalid url']));
 

--- a/apps/account-api/src/api.config.ts
+++ b/apps/account-api/src/api.config.ts
@@ -7,7 +7,7 @@ export interface IAccountApiConfig {
   apiBodyJsonLimit: string;
   apiPort: number;
   apiTimeoutMs: number;
-  siwfNodeRpcUrl: URL;
+  siwfNodeRpcUrl?: URL;
   graphEnvironmentType: keyof EnvironmentType;
   siwfUrl: string;
   siwfV2Url?: string;
@@ -30,7 +30,7 @@ export default registerAs('account-api', (): IAccountApiConfig => {
     },
     siwfNodeRpcUrl: {
       label: 'SIWF_NODE_RPC_URL',
-      joi: Joi.string().uri().required(),
+      joi: Joi.string().uri(),
     },
     graphEnvironmentType: {
       label: 'GRAPH_ENVIRONMENT_TYPE',

--- a/apps/account-api/src/services/accounts.service.ts
+++ b/apps/account-api/src/services/accounts.service.ts
@@ -67,7 +67,7 @@ export class AccountsService {
     return {
       providerId: providerId.toString(),
       siwfUrl: siwfUrl.toString(),
-      frequencyRpcUrl: siwfNodeRpcUrl.toString(),
+      frequencyRpcUrl: siwfNodeRpcUrl?.toString(),
     };
   }
 

--- a/apps/account-api/src/services/siwfV2.service.ts
+++ b/apps/account-api/src/services/siwfV2.service.ts
@@ -285,7 +285,7 @@ export class SiwfV2Service {
         permissions,
         SiwfV2Service.requestedCredentialTypesToFullRequest(requestCredentials),
       );
-      const frequencyRpcUrl = siwfNodeRpcUrl.toString();
+      const frequencyRpcUrl = siwfNodeRpcUrl?.toString();
       response = {
         signedRequest,
         redirectUrl: generateAuthenticationUrl(signedRequest, new URLSearchParams({ frequencyRpcUrl }), {


### PR DESCRIPTION
# Problem

SIWF_NODE_RPC_URL is only used for SIWF v1, which will soon be removed. We should make the env var optional as a temporary measure.

Link to GitHub Issue(s): [#889 ](https://github.com/ProjectLibertyLabs/gateway/issues/889)

# Solution

Remove required validation, cleanup tests, 

## Steps to Verify:

1. Remove SIWF_NODE_RPC_URL from `.env` and `.env.account` files
2. Run account services: `docker compose -f docker-compose.yaml -f docker-compose-e2e.account.yaml --profile account --profile e2e up -d` 
3. Ensure SIWF_NODE_RPC_URL is not set
4. Run e2e testing to confirm application is running: `npm run test:e2e:account`
