### PR TITLE
fix: confirm blockchain api is ready on service bootstrap

### DIFF
--- a/apps/account-worker/src/transaction_publisher/publisher.service.ts
+++ b/apps/account-worker/src/transaction_publisher/publisher.service.ts
@@ -41,6 +41,7 @@ const CAPACITY_EPOCH_TIMEOUT_NAME = 'capacity_check';
 @Processor(QueueConstants.TRANSACTION_PUBLISH_QUEUE)
 export class TransactionPublisherService extends BaseConsumer implements OnApplicationBootstrap, OnApplicationShutdown {
   public async onApplicationBootstrap() {
+    await this.blockchainService.isReady();
     await this.capacityCheckerService.checkForSufficientCapacity();
     this.worker.concurrency = this.accountWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 1;
   }

--- a/apps/content-publishing-worker/src/publisher/publishing.service.ts
+++ b/apps/content-publishing-worker/src/publisher/publishing.service.ts
@@ -38,6 +38,7 @@ export class PublishingService extends BaseConsumer implements OnApplicationBoot
   }
 
   public async onApplicationBootstrap() {
+    await this.blockchainService.isReady();
     this.worker.concurrency = this.cpWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 2;
     await this.capacityCheckerService.checkForSufficientCapacity();
   }

--- a/apps/graph-worker/src/graph_notifier/graph.monitor.service.ts
+++ b/apps/graph-worker/src/graph_notifier/graph.monitor.service.ts
@@ -1,6 +1,6 @@
 import { InjectRedis } from '@songkeys/nestjs-redis';
 import { InjectQueue } from '@nestjs/bullmq';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common';
 import { Queue } from 'bullmq';
 import Redis from 'ioredis';
 import { MILLISECONDS_PER_SECOND } from 'time-constants';
@@ -29,7 +29,10 @@ type GraphOperationStatus = GraphServiceWebhook.Components.Schemas.GraphOperatio
 type StatusUpdate = IGraphTxStatus & GraphOperationStatus;
 
 @Injectable()
-export class GraphMonitorService extends BlockchainScannerService {
+export class GraphMonitorService
+  extends BlockchainScannerService
+  implements OnApplicationBootstrap, OnApplicationShutdown
+{
   private graphSchemaIds: number[];
 
   async onApplicationBootstrap() {

--- a/apps/graph-worker/src/graph_publisher/graph.publisher.processor.service.ts
+++ b/apps/graph-worker/src/graph_publisher/graph.publisher.processor.service.ts
@@ -29,6 +29,7 @@ const CAPACITY_EPOCH_TIMEOUT_NAME = 'capacity_check';
 @Processor(QueueConstants.GRAPH_CHANGE_PUBLISH_QUEUE)
 export class GraphUpdatePublisherService extends BaseConsumer implements OnApplicationBootstrap, OnApplicationShutdown {
   public async onApplicationBootstrap() {
+    await this.blockchainService.isReady();
     this.worker.concurrency = this.graphWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 1;
     await this.capacityCheckerService.checkForSufficientCapacity();
   }

--- a/apps/graph-worker/src/request_processor/request.processor.service.ts
+++ b/apps/graph-worker/src/request_processor/request.processor.service.ts
@@ -31,7 +31,8 @@ import { pino } from 'pino';
 @Injectable()
 @Processor(QueueConstants.GRAPH_CHANGE_REQUEST_QUEUE)
 export class RequestProcessorService extends BaseConsumer implements OnApplicationBootstrap, OnModuleDestroy {
-  public onApplicationBootstrap() {
+  public async onApplicationBootstrap() {
+    await this.blockchainService.isReady();
     this.worker.concurrency = this.graphWorkerConfig[`${this.worker.name}QueueWorkerConcurrency`] || 1;
   }
 


### PR DESCRIPTION
# Problem

On worker start-up, if there are already queued jobs, it is possible jobs are already processed before dependencies are ready.

e.g.
`ERROR [TransactionPublisherService] Error: Api interfaces needs to be initialized before using, wait for 'isReady'`

Link to GitHub Issue(s): [#780 ](https://github.com/ProjectLibertyLabs/gateway/issues/780)

# Solution

An existing approach has been to add a blockchain API ready check on worker service bootstrap. I went ahead and added this to all services that depend on the Blockchain Service (and don't already check if the API is ready).

## Steps to Verify:

## Screenshots (optional):
