### PR TITLE
Small fix to recent commit to make spellchecker pass

### DIFF
--- a/.spellcheckerdict.txt
+++ b/.spellcheckerdict.txt
@@ -133,7 +133,7 @@ Supertest
 svg-embed
 TCP
 Terraform
-(Testnet|TestNet)
+(Testnet|TestNet|testnet)
 TestnetPaseo
 TLS
 Traefik


### PR DESCRIPTION
Recent update to README added "testnet" as a term. Adding it to the spellchecker. 