### PR TITLE
Gippity fix: clear timeout in withTimeoutMs

### DIFF
--- a/libs/utils/src/common/common.utils.spec.ts
+++ b/libs/utils/src/common/common.utils.spec.ts
@@ -1,4 +1,4 @@
-import { calculateDsnpMultiHash, calculateIncrementalDsnpMultiHash } from '#utils/common/common.utils';
+import { calculateDsnpMultiHash, calculateIncrementalDsnpMultiHash, withTimeoutMs } from '#utils/common/common.utils';
 import { Readable } from 'stream';
 import {
   getKeypairTypeForProviderKey,
@@ -68,5 +68,18 @@ describe('common utils Tests', () => {
     const unifiedAthAddr = ethAddr + 'ee'.repeat(12);
     expect(getUnifiedAddressFromAddress(unifiedAthAddr)).toEqual(unifiedAthAddr);
     expect(getUnifiedAddressFromAddress(ss58UnifiedEthAddr)).toEqual(ss58UnifiedEthAddr);
+  });
+
+  it('withTimeoutMs resolves without leaving hanging timers', async () => {
+    jest.useFakeTimers();
+    const unhandledRejection = jest.fn();
+    process.on('unhandledRejection', unhandledRejection);
+
+    await expect(withTimeoutMs(Promise.resolve('done'), 1000)).resolves.toBe('done');
+    jest.advanceTimersByTime(1000);
+
+    expect(unhandledRejection).not.toHaveBeenCalled();
+    process.off('unhandledRejection', unhandledRejection);
+    jest.useRealTimers();
   });
 });

--- a/libs/utils/src/common/common.utils.ts
+++ b/libs/utils/src/common/common.utils.ts
@@ -14,12 +14,21 @@ export async function delayMS(ms: number): Promise<void> {
 }
 
 export function withTimeoutMs<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new Error(`Operation timed out after ${timeoutMs}ms`)), timeoutMs);
-    }),
-  ]);
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`Operation timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise
+      .then((value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      })
+      .catch((err) => {
+        clearTimeout(timeoutId);
+        reject(err);
+      });
+  });
 }
 
 export async function calculateIpfsCID(buffer: Buffer): Promise<string> {


### PR DESCRIPTION
## Summary
This is a test of an automatically generated PR from a basic Codex prompt, "Pick a part of the codebase that seems important and find and fix a bug."

- ensure withTimeoutMs clears its timer once the wrapped promise settles to avoid unhandled rejections
- add regression test verifying resolved promises do not trigger lingering timeouts

## Testing
- `npm run test:libs:utils`


------
https://chatgpt.com/codex/tasks/task_b_68b9d48b03e8832e88a75be6d3fda28b