### PR TITLE
Add missing delay for exponential backoff

### DIFF
--- a/libs/types/src/constants/queue.constants.ts
+++ b/libs/types/src/constants/queue.constants.ts
@@ -72,6 +72,7 @@ export namespace ContentWatcherQueues {
         attempts: 3,
         backoff: {
           type: 'exponential',
+          delay: 1000,
         },
         removeOnComplete: true,
         removeOnFail: false,
@@ -199,6 +200,7 @@ export namespace ContentPublishingQueues {
           attempts: 1,
           backoff: {
             type: 'exponential',
+            delay: 1000,
           },
           removeOnComplete: true,
           removeOnFail: false,
@@ -210,6 +212,7 @@ export namespace ContentPublishingQueues {
           attempts: 1,
           backoff: {
             type: 'exponential',
+            delay: 6000,
           },
           removeOnComplete: true,
           removeOnFail: false,


### PR DESCRIPTION
# Problem

Exponential backoff had no delay configured so operations that encountered errors would be retried immediately.

# Solution

Introduce a reasonable delay.

I used 1000ms as the default, but 6000ms for the Publish Queue, where errors have been observed, and waiting at least until the next block might allow a working nonce to be retrieved.

It is likely unnecessary to add a delay where `attempts` is set to `1`, but I added those as a best practice to avoid confusion if `attempts` is ever changed.

No tests included as I think we'd just be testing whether the queueing library worked.