### PR TITLE
fix: merge bull queue defaults properly

### DIFF
--- a/libs/queue/src/queue.module.ts
+++ b/libs/queue/src/queue.module.ts
@@ -35,7 +35,8 @@ export class QueueModule {
             removeOnComplete: 100,
             removeOnFail: 50,
             attempts: 3,
-            backoff: {
+            ...options?.config?.defaultJobOptions,
+            backoff: options?.config?.defaultJobOptions?.backoff || {
               type: 'exponential',
               delay: 2000,
             },

--- a/libs/types/src/constants/queue.constants.ts
+++ b/libs/types/src/constants/queue.constants.ts
@@ -70,9 +70,6 @@ export namespace ContentWatcherQueues {
     config: {
       defaultJobOptions: {
         attempts: 3,
-        backoff: {
-          type: 'exponential',
-        },
         removeOnComplete: true,
         removeOnFail: false,
       },
@@ -197,9 +194,6 @@ export namespace ContentPublishingQueues {
         name: BATCH_QUEUE_NAME,
         defaultJobOptions: {
           attempts: 1,
-          backoff: {
-            type: 'exponential',
-          },
           removeOnComplete: true,
           removeOnFail: false,
         },
@@ -208,9 +202,6 @@ export namespace ContentPublishingQueues {
         name: PUBLISH_QUEUE_NAME,
         defaultJobOptions: {
           attempts: 1,
-          backoff: {
-            type: 'exponential',
-          },
           removeOnComplete: true,
           removeOnFail: false,
         },


### PR DESCRIPTION
# Problem
The default queue options for Bull queues are not merged correctly.

# Solution
Merge the properties correctly

Closes #958 