### PR TITLE
Remove ultra light CI load test on PRs

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -144,25 +144,6 @@ jobs:
         if: ${{ steps.should.outputs.RUN == 'true' }}
         uses: grafana/setup-k6-action@v1
 
-      - name: Run k6 Tests - PR Mode (Ultra Light Load Only)
-        if: ${{ steps.should.outputs.RUN == 'true' && steps.test-type.outputs.test_type == 'pr' }}
-        run: |
-          for test_file in apps/${{ matrix.service }}/k6-test/*.k6.js; do
-            # Skip stress tests for PRs
-            if [[ "$test_file" == *"stress"* ]]; then
-              echo "Skipping stress test: $test_file (PR mode)"
-              continue
-            fi
-            # Run batch announcement tests with ultra light scenario for CI
-            if [[ "$test_file" == *"batch-announcement-load"* ]]; then
-              echo "Running batch announcement test with ultra light scenario: $test_file"
-              k6 run --no-color --quiet --no-usage-report -e SCENARIO=ultra_light "$test_file" || exit 1
-            else
-              echo "Running test: $test_file"
-              k6 run --no-color --quiet --no-usage-report "$test_file" || exit 1
-            fi
-          done
-
       - name: Run k6 Tests - Release Mode (Medium Load + Stress Tests)
         if: ${{ steps.should.outputs.RUN == 'true' && steps.test-type.outputs.test_type == 'release' }}
         run: |


### PR DESCRIPTION
# Problem

Currently, the CI is having issues meeting load test thresholds. This is variable as we are not sure what kind of CPU & memory allocation CI is running on.

# Solution

For the time being, instead of arbitrarily lowering thresholds, lets remove this CI job, and research how to make reasonable load tests a part of CI. Will create a related issue. 