### PR TITLE
Put limits on job queue retention

### DIFF
--- a/libs/types/src/constants/queue.constants.ts
+++ b/libs/types/src/constants/queue.constants.ts
@@ -24,7 +24,7 @@ export namespace AccountQueues {
         name: TRANSACTION_PUBLISH_QUEUE,
         defaultJobOptions: {
           removeOnComplete: 20,
-          removeOnFail: false,
+          removeOnFail: 1000,
           attempts: 1,
         },
       },
@@ -71,7 +71,7 @@ export namespace ContentWatcherQueues {
       defaultJobOptions: {
         attempts: 3,
         removeOnComplete: true,
-        removeOnFail: false,
+        removeOnFail: 1000,
       },
     },
     queues: [
@@ -195,7 +195,7 @@ export namespace ContentPublishingQueues {
         defaultJobOptions: {
           attempts: 1,
           removeOnComplete: true,
-          removeOnFail: false,
+          removeOnFail: 1000,
         },
       },
       {
@@ -203,7 +203,7 @@ export namespace ContentPublishingQueues {
         defaultJobOptions: {
           attempts: 1,
           removeOnComplete: true,
-          removeOnFail: false,
+          removeOnFail: 1000,
           backoff: {
             type: 'exponential',
             delay: 6000,
@@ -243,7 +243,7 @@ export namespace GraphQueues {
         name: GRAPH_CHANGE_REQUEST_QUEUE,
         defaultJobOptions: {
           removeOnComplete: true,
-          removeOnFail: false,
+          removeOnFail: 1000,
           attempts: 3,
         },
       },
@@ -251,15 +251,15 @@ export namespace GraphQueues {
         name: GRAPH_CHANGE_PUBLISH_QUEUE,
         defaultJobOptions: {
           removeOnComplete: true,
-          removeOnFail: false,
+          removeOnFail: 1000,
           attempts: 1,
         },
       },
       {
         name: RECONNECT_REQUEST_QUEUE,
         defaultJobOptions: {
-          removeOnComplete: false,
-          removeOnFail: false,
+          removeOnComplete: 100,
+          removeOnFail: 1000,
           attempts: 3,
         },
       },


### PR DESCRIPTION
# Purpose

The goal of this PR is to prevent the unbounded growth of Redis cache usage by placing limits on the job queue retention policy.

Closes #976 

### Checklist

items that don't apply can be marked NA or deleted

- [ ] Unit tests added
- [ ] Integration/end-to-end tests added
- [ ] Documentation added or updated (where applicable)
- [ ] API endpoints added or changed? Swagger docs regenerated
- [ ] Breaking changes? "breaking changes" label added
