### PR TITLE
Some housekeeping including swagger doc regen

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ items that don't apply can be marked NA or deleted
 - [ ] Unit tests added
 - [ ] Integration/end-to-end tests added
 - [ ] Documentation added or updated (where applicable)
-- [ ] API endpoints added or changed? Swagger docs regenerated
+- [ ] API endpoints added or changed? Added the endpoints in main.ts and regenerated Swagger docs
 - [ ] Breaking changes? "breaking changes" label added
 
 ## Additional details / screenshot

--- a/apps/content-publishing-api/src/main.ts
+++ b/apps/content-publishing-api/src/main.ts
@@ -50,7 +50,7 @@ async function bootstrap() {
         'x-tagGroups',
         [
           { name: 'asset', tags: ['v1/asset', 'v2/asset'] },
-          { name: 'content', tags: ['v1/content', 'v2/content'] },
+          { name: 'content', tags: ['v1/content', 'v2/content', 'v3/content'] },
           { name: 'health', tags: ['health'] },
           { name: 'profile', tags: ['v1/profile'] },
         ],

--- a/apps/content-publishing-api/test/app-v3-content-batchAnnouncement.e2e-spec.ts
+++ b/apps/content-publishing-api/test/app-v3-content-batchAnnouncement.e2e-spec.ts
@@ -1,0 +1,213 @@
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApiModule } from '#content-publishing-api/api.module';
+import { ApiService } from '../src/api.service';
+import request from 'supertest';
+import {
+  CONFIGURED_QUEUE_NAMES_PROVIDER,
+  CONFIGURED_QUEUE_PREFIX_PROVIDER,
+  ContentPublishingQueues as QueueConstants,
+} from '#types/constants';
+import apiConfig, { IContentPublishingApiConfig } from '#content-publishing-api/api.config';
+import { ValidationPipe, VersioningType } from '@nestjs/common';
+import { TimeoutInterceptor } from '#utils/interceptors/timeout.interceptor';
+import { Logger } from 'nestjs-pino';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+describe('AppController E2E request verification', () => {
+  let app: NestExpressApplication;
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [ApiModule],
+      providers: [
+        {
+          provide: CONFIGURED_QUEUE_NAMES_PROVIDER,
+          useValue: QueueConstants.CONFIGURED_QUEUES.queues.map(({ name }) => name),
+        },
+        {
+          provide: CONFIGURED_QUEUE_PREFIX_PROVIDER,
+          useValue: 'content-publishing::bull',
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+
+    // Uncomment below to see logs when debugging tests
+    // module.useLogger(new Logger());
+
+    const config = app.get<IContentPublishingApiConfig>(apiConfig.KEY);
+    app.enableVersioning({ type: VersioningType.URI });
+    app.enableShutdownHooks();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+        transformOptions: {
+          enableImplicitConversion: true,
+        },
+        enableDebugMessages: true,
+      }),
+    );
+    app.useGlobalInterceptors(new TimeoutInterceptor(config.apiTimeoutMs));
+    app.useBodyParser('json', { limit: config.apiBodyJsonLimit });
+    app.useLogger(app.get(Logger));
+
+    const eventEmitter = app.get<EventEmitter2>(EventEmitter2);
+    eventEmitter.on('shutdown', async () => {
+      await app.close();
+    });
+    await app.init();
+  });
+
+  describe('(POST) /v3/content/batchAnnouncement', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should reject request without files', async () => {
+      await request(app.getHttpServer())
+        .post('/v3/content/batchAnnouncement')
+        .expect(400)
+        .expect((res) => expect(res.text).toContain('No files provided'));
+    }, 30000);
+
+    it('should accept valid files with matching schema IDs', async () => {
+      const imageContent = Buffer.from('fake image content');
+
+      await request(app.getHttpServer())
+        .post('/v3/content/batchAnnouncement')
+        .attach('files', imageContent, { filename: 'test.jpg', contentType: 'image/jpeg' })
+        .field('schemaId', '12')
+        .expect(202)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('files');
+          expect(Array.isArray(res.body.files)).toBe(true);
+          expect(res.body.files.length).toBeGreaterThan(0);
+          expect(res.body.files[0]).toHaveProperty('referenceId');
+        });
+    }, 30000);
+
+    it('should process multiple files in a single request', async () => {
+      const file1 = Buffer.from('fake image content 1');
+      const file2 = Buffer.from('fake image content 2');
+
+      await request(app.getHttpServer())
+        .post('/v3/content/batchAnnouncement')
+        .attach('files', file1, { filename: 'test1.jpg', contentType: 'image/jpeg' })
+        .attach('files', file2, { filename: 'test2.png', contentType: 'image/png' })
+        .field('schemaId', '12')
+        .field('schemaId', '12')
+        .expect(202)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('files');
+          expect(Array.isArray(res.body.files)).toBe(true);
+          expect(res.body.files.length).toBe(2);
+          expect(res.body.files[0]).toHaveProperty('referenceId');
+          expect(res.body.files[1]).toHaveProperty('referenceId');
+        });
+    }, 30000);
+
+    it('should handle mixed success and failure scenarios', async () => {
+      // Mock the ApiService to simulate failure for files with specific content
+      const apiService = app.get(ApiService);
+
+      // Mock to fail uploads for files with "fail" in the filename
+      jest.spyOn(apiService, 'uploadStreamedAsset').mockImplementation(async (stream, filename) => {
+        // Consume the stream to prevent hanging
+        const chunks: any[] = [];
+        // Convert async iterable to array to avoid for-await-of loop
+        const streamIterator = stream[Symbol.asyncIterator]();
+        let result = await streamIterator.next();
+        while (!result.done) {
+          chunks.push(result.value);
+          result = await streamIterator.next();
+        }
+
+        if (filename.includes('fail')) {
+          return { error: 'Simulated upload failure' };
+        }
+        // For non-failing files, return a successful response
+        return { cid: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi' };
+      });
+
+      const successFile = Buffer.from('fake image content success');
+      const failFile = Buffer.from('fake image content fail');
+
+      await request(app.getHttpServer())
+        .post('/v3/content/batchAnnouncement')
+        .attach('files', successFile, { filename: 'success.jpg', contentType: 'image/jpeg' })
+        .attach('files', failFile, { filename: 'fail.png', contentType: 'image/png' })
+        .field('schemaId', '12')
+        .field('schemaId', '12')
+        .expect(207) // Multi-Status for partial success
+        .expect((res) => {
+          expect(res.body).toHaveProperty('files');
+          expect(Array.isArray(res.body.files)).toBe(true);
+          expect(res.body.files.length).toBe(2);
+
+          // First file should succeed
+          expect(res.body.files[0]).toHaveProperty('referenceId');
+          expect(res.body.files[0]).toHaveProperty('cid');
+          expect(res.body.files[0]).not.toHaveProperty('error');
+
+          // Second file should fail
+          expect(res.body.files[1]).toHaveProperty('error');
+          expect(res.body.files[1].error).toBe('Simulated upload failure');
+          expect(res.body.files[1]).not.toHaveProperty('referenceId');
+          expect(res.body.files[1]).not.toHaveProperty('cid');
+        });
+    }, 30000);
+
+    it('should handle batch announcement failures after successful uploads', async () => {
+      // Mock the ApiService methods
+      const apiService = app.get(ApiService);
+
+      // Mock successful upload but failed batch creation
+      jest.spyOn(apiService, 'uploadStreamedAsset').mockImplementation(async (stream) => {
+        // Consume the stream to prevent hanging
+        const chunks: any[] = [];
+        const streamIterator = stream[Symbol.asyncIterator]();
+        let result = await streamIterator.next();
+        while (!result.done) {
+          chunks.push(result.value);
+          result = await streamIterator.next();
+        }
+        return { cid: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi' };
+      });
+
+      jest.spyOn(apiService, 'enqueueBatchRequest').mockRejectedValue(new Error('Batch creation failed'));
+
+      const file = Buffer.from('fake image content');
+
+      await request(app.getHttpServer())
+        .post('/v3/content/batchAnnouncement')
+        .attach('files', file, { filename: 'test.jpg', contentType: 'image/jpeg' })
+        .field('schemaId', '12')
+        .expect(207) // Multi-Status when batch creation fails after successful uploads
+        .expect((res) => {
+          expect(res.body).toHaveProperty('files');
+          expect(Array.isArray(res.body.files)).toBe(true);
+          expect(res.body.files.length).toBe(1);
+
+          // Should have CID but error due to batch failure
+          expect(res.body.files[0]).toHaveProperty('cid');
+          expect(res.body.files[0]).toHaveProperty('error');
+          expect(res.body.files[0].error).toBe('Upload to IPFS succeeded, but batch announcement to chain failed');
+          expect(res.body.files[0]).not.toHaveProperty('referenceId');
+        });
+
+      // Restore the original method
+    }, 30000);
+  });
+
+  afterAll(async () => {
+    try {
+      await app.close();
+    } catch (err) {
+      console.error(err);
+    }
+  }, 60000);
+});

--- a/apps/content-publishing-api/test/app.e2e-spec.ts
+++ b/apps/content-publishing-api/test/app.e2e-spec.ts
@@ -4,7 +4,6 @@ import request from 'supertest';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomBytes, randomFill } from 'crypto';
 import { ApiModule } from '../src/api.module';
-import { ApiService } from '../src/api.service';
 import {
   validBroadCastNoUploadedAssets,
   validContentNoUploadedAssets,
@@ -30,7 +29,7 @@ const randomString = (length: number, _unused) =>
 
 validOnChainContent.payload = randomString(1024, null);
 
-describe('AppController E2E request verification!', () => {
+describe('AppController E2E request verification', () => {
   let app: NestExpressApplication;
   let module: TestingModule;
 
@@ -888,147 +887,6 @@ describe('AppController E2E request verification!', () => {
         .attach('files', Buffer.from(buffer), 'file1.jpg')
         .expect(202);
     }, 15000);
-  });
-
-  describe('(POST) /v3/content/batchAnnouncement', () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it('should reject request without files', async () => {
-      await request(app.getHttpServer())
-        .post('/v3/content/batchAnnouncement')
-        .expect(400)
-        .expect((res) => expect(res.text).toContain('No files provided'));
-    }, 30000);
-
-    it('should accept valid files with matching schema IDs', async () => {
-      const imageContent = Buffer.from('fake image content');
-
-      await request(app.getHttpServer())
-        .post('/v3/content/batchAnnouncement')
-        .attach('files', imageContent, { filename: 'test.jpg', contentType: 'image/jpeg' })
-        .field('schemaId', '12')
-        .expect(202)
-        .expect((res) => {
-          expect(res.body).toHaveProperty('files');
-          expect(Array.isArray(res.body.files)).toBe(true);
-          expect(res.body.files.length).toBeGreaterThan(0);
-          expect(res.body.files[0]).toHaveProperty('referenceId');
-        });
-    }, 30000);
-
-    it('should process multiple files in a single request', async () => {
-      const file1 = Buffer.from('fake image content 1');
-      const file2 = Buffer.from('fake image content 2');
-
-      await request(app.getHttpServer())
-        .post('/v3/content/batchAnnouncement')
-        .attach('files', file1, { filename: 'test1.jpg', contentType: 'image/jpeg' })
-        .attach('files', file2, { filename: 'test2.png', contentType: 'image/png' })
-        .field('schemaId', '12')
-        .field('schemaId', '12')
-        .expect(202)
-        .expect((res) => {
-          expect(res.body).toHaveProperty('files');
-          expect(Array.isArray(res.body.files)).toBe(true);
-          expect(res.body.files.length).toBe(2);
-          expect(res.body.files[0]).toHaveProperty('referenceId');
-          expect(res.body.files[1]).toHaveProperty('referenceId');
-        });
-    }, 30000);
-
-    it('should handle mixed success and failure scenarios', async () => {
-      // Mock the ApiService to simulate failure for files with specific content
-      const apiService = app.get(ApiService);
-
-      // Mock to fail uploads for files with "fail" in the filename
-      jest.spyOn(apiService, 'uploadStreamedAsset').mockImplementation(async (stream, filename) => {
-        // Consume the stream to prevent hanging
-        const chunks: any[] = [];
-        // Convert async iterable to array to avoid for-await-of loop
-        const streamIterator = stream[Symbol.asyncIterator]();
-        let result = await streamIterator.next();
-        while (!result.done) {
-          chunks.push(result.value);
-          result = await streamIterator.next();
-        }
-
-        if (filename.includes('fail')) {
-          return { error: 'Simulated upload failure' };
-        }
-        // For non-failing files, return a successful response
-        return { cid: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi' };
-      });
-
-      const successFile = Buffer.from('fake image content success');
-      const failFile = Buffer.from('fake image content fail');
-
-      await request(app.getHttpServer())
-        .post('/v3/content/batchAnnouncement')
-        .attach('files', successFile, { filename: 'success.jpg', contentType: 'image/jpeg' })
-        .attach('files', failFile, { filename: 'fail.png', contentType: 'image/png' })
-        .field('schemaId', '12')
-        .field('schemaId', '12')
-        .expect(207) // Multi-Status for partial success
-        .expect((res) => {
-          expect(res.body).toHaveProperty('files');
-          expect(Array.isArray(res.body.files)).toBe(true);
-          expect(res.body.files.length).toBe(2);
-
-          // First file should succeed
-          expect(res.body.files[0]).toHaveProperty('referenceId');
-          expect(res.body.files[0]).toHaveProperty('cid');
-          expect(res.body.files[0]).not.toHaveProperty('error');
-
-          // Second file should fail
-          expect(res.body.files[1]).toHaveProperty('error');
-          expect(res.body.files[1].error).toBe('Simulated upload failure');
-          expect(res.body.files[1]).not.toHaveProperty('referenceId');
-          expect(res.body.files[1]).not.toHaveProperty('cid');
-        });
-    }, 30000);
-
-    it('should handle batch announcement failures after successful uploads', async () => {
-      // Mock the ApiService methods
-      const apiService = app.get(ApiService);
-
-      // Mock successful upload but failed batch creation
-      jest.spyOn(apiService, 'uploadStreamedAsset').mockImplementation(async (stream) => {
-        // Consume the stream to prevent hanging
-        const chunks: any[] = [];
-        const streamIterator = stream[Symbol.asyncIterator]();
-        let result = await streamIterator.next();
-        while (!result.done) {
-          chunks.push(result.value);
-          result = await streamIterator.next();
-        }
-        return { cid: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi' };
-      });
-
-      jest.spyOn(apiService, 'enqueueBatchRequest').mockRejectedValue(new Error('Batch creation failed'));
-
-      const file = Buffer.from('fake image content');
-
-      await request(app.getHttpServer())
-        .post('/v3/content/batchAnnouncement')
-        .attach('files', file, { filename: 'test.jpg', contentType: 'image/jpeg' })
-        .field('schemaId', '12')
-        .expect(207) // Multi-Status when batch creation fails after successful uploads
-        .expect((res) => {
-          expect(res.body).toHaveProperty('files');
-          expect(Array.isArray(res.body.files)).toBe(true);
-          expect(res.body.files.length).toBe(1);
-
-          // Should have CID but error due to batch failure
-          expect(res.body.files[0]).toHaveProperty('cid');
-          expect(res.body.files[0]).toHaveProperty('error');
-          expect(res.body.files[0].error).toBe('Upload to IPFS succeeded, but batch announcement to chain failed');
-          expect(res.body.files[0]).not.toHaveProperty('referenceId');
-        });
-
-      // Restore the original method
-    }, 30000);
   });
 
   afterAll(async () => {

--- a/openapi-specs/content-publishing.openapi.json
+++ b/openapi-specs/content-publishing.openapi.json
@@ -1063,7 +1063,8 @@
       "name": "content",
       "tags": [
         "v1/content",
-        "v2/content"
+        "v2/content",
+        "v3/content"
       ]
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,14 +1403,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -1478,19 +1478,19 @@
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
-      "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.3",
+        "@babel/traverse": "^7.28.5",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1512,15 +1512,15 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "regexpu-core": "^6.2.0",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "regexpu-core": "^6.3.1",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1570,15 +1570,15 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1855,13 +1855,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2266,9 +2266,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.4.tgz",
-      "integrity": "sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.5.tgz",
+      "integrity": "sha512-45DmULpySVvmq9Pj3X9B+62Xe+DJGov27QravQJU1LLcapR6/10i+gYVAucGGJpHBp5mYxIMK4nDAT/QDLr47g==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2359,15 +2359,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
-      "integrity": "sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.0"
+        "@babel/traverse": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2466,9 +2466,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
-      "integrity": "sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.5.tgz",
+      "integrity": "sha512-axUuqnUTBuXyHGcJEVVh9pORaN6wC5bYfE7FGzPiaWa3syib9m7g+/IT/4VgCOe2Upef43PHzeAvcrVek6QuuA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2591,9 +2591,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
-      "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.5.tgz",
+      "integrity": "sha512-N6fut9IZlPnjPwgiQkXNhb+cT8wQKFlJNqcZkWlcTqkcqx6/kU4ynGmLFoa4LViBSirn05YAwk+sQBbPfxtYzQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2787,9 +2787,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
-      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.5.tgz",
+      "integrity": "sha512-20NUVgOrinudkIBzQ2bNxP08YpKprUkRTiRSd2/Z5GOdPImJGkoN4Z7IQe1T5AdyKI1i5L6RBmluqdSzvaq9/w==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2872,15 +2872,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
-      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
+      "integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.28.5",
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1"
@@ -2911,16 +2911,16 @@
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.27.1.tgz",
-      "integrity": "sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.28.5.tgz",
+      "integrity": "sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-transform-react-display-name": "^7.27.1",
+        "@babel/plugin-transform-react-display-name": "^7.28.0",
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-react-jsx-development": "^7.27.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
@@ -2933,9 +2933,9 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
-      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2944,7 +2944,7 @@
         "@babel/helper-validator-option": "^7.27.1",
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-        "@babel/plugin-transform-typescript": "^7.27.1"
+        "@babel/plugin-transform-typescript": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2980,18 +2980,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/generator": "^7.28.5",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
+        "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/types": "^7.28.5",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -3000,19 +3000,19 @@
     },
     "node_modules/@babel/traverse--for-generate-function-map": {
       "name": "@babel/traverse",
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/generator": "^7.28.5",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
+        "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/types": "^7.28.5",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -3020,14 +3020,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4896,9 +4896,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "54.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.11.tgz",
-      "integrity": "sha512-ik9p8+JTOuVXS462+vFPV0qnWRBXIR1bPmoVKO8xQWw6Yk+K6UlU2GrM2ch7kA3JlSJE/MGsNyN8CB0zFZbVbQ==",
+      "version": "54.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.16.tgz",
+      "integrity": "sha512-hY/OdRaJMs5WsVPuVSZ+RLH3VObJmL/pv5CGCHEZHN2PxZjSZSdctyKV8UcFBXTF0yIKNAJ9XLs1dlNYXHh4Cw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -4911,18 +4911,18 @@
         "@expo/env": "~2.0.7",
         "@expo/image-utils": "^0.8.7",
         "@expo/json-file": "^10.0.7",
-        "@expo/mcp-tunnel": "~0.0.7",
-        "@expo/metro": "~54.0.0",
-        "@expo/metro-config": "~54.0.6",
+        "@expo/mcp-tunnel": "~0.1.0",
+        "@expo/metro": "~54.1.0",
+        "@expo/metro-config": "~54.0.9",
         "@expo/osascript": "^2.3.7",
         "@expo/package-manager": "^1.9.8",
         "@expo/plist": "^0.4.7",
-        "@expo/prebuild-config": "^54.0.5",
+        "@expo/prebuild-config": "^54.0.6",
         "@expo/schema-utils": "^0.1.7",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "0.81.4",
+        "@react-native/dev-middleware": "0.81.5",
         "@urql/core": "^5.0.6",
         "@urql/exchange-retry": "^1.3.0",
         "accepts": "^1.3.8",
@@ -4936,7 +4936,7 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
-        "expo-server": "^1.0.1",
+        "expo-server": "^1.0.4",
         "freeport-async": "^2.0.0",
         "getenv": "^2.0.0",
         "glob": "^10.4.2",
@@ -5461,10 +5461,10 @@
       }
     },
     "node_modules/@expo/cli/node_modules/tar": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
-      "license": "ISC",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5995,9 +5995,9 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.1.tgz",
-      "integrity": "sha512-U1S9DwiapCHQjHdHDDyO/oXsl/1oEHSHZRRkWDDrHgXRUDiAVIySw9Unvvcr118Ee6/x4NmKSZY1X0VagrqmFg==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.3.tgz",
+      "integrity": "sha512-8YPJpEYlmV171fi+t+cSLMX1nC5ngY9j2FiN70dHldLpd6Ct6ouGhk96svJ4BQZwsqwII2pokwzrDAwqo4Z0FQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -6177,9 +6177,9 @@
       }
     },
     "node_modules/@expo/mcp-tunnel": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/mcp-tunnel/-/mcp-tunnel-0.0.8.tgz",
-      "integrity": "sha512-6261obzt6h9TQb6clET7Fw4Ig4AY2hfTNKI3gBt0gcTNxZipwMg8wER7ssDYieA9feD/FfPTuCPYFcR280aaWA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@expo/mcp-tunnel/-/mcp-tunnel-0.1.0.tgz",
+      "integrity": "sha512-rJ6hl0GnIZj9+ssaJvFsC7fwyrmndcGz+RGFzu+0gnlm78X01957yjtHgjcmnQAgL5hWEOR6pkT0ijY5nU5AWw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -6198,31 +6198,31 @@
       }
     },
     "node_modules/@expo/metro": {
-      "version": "54.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/metro/-/metro-54.0.0.tgz",
-      "integrity": "sha512-x2HlliepLJVLSe0Fl/LuPT83Mn2EXpPlb1ngVtcawlz4IfbkYJo16/Zfsfrn1t9d8LpN5dD44Dc55Q1/fO05Nw==",
+      "version": "54.1.0",
+      "resolved": "https://registry.npmjs.org/@expo/metro/-/metro-54.1.0.tgz",
+      "integrity": "sha512-MgdeRNT/LH0v1wcO0TZp9Qn8zEF0X2ACI0wliPtv5kXVbXWI+yK9GyrstwLAiTXlULKVIg3HVSCCvmLu0M3tnw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "metro": "0.83.1",
-        "metro-babel-transformer": "0.83.1",
-        "metro-cache": "0.83.1",
-        "metro-cache-key": "0.83.1",
-        "metro-config": "0.83.1",
-        "metro-core": "0.83.1",
-        "metro-file-map": "0.83.1",
-        "metro-resolver": "0.83.1",
-        "metro-runtime": "0.83.1",
-        "metro-source-map": "0.83.1",
-        "metro-transform-plugins": "0.83.1",
-        "metro-transform-worker": "0.83.1"
+        "metro": "0.83.2",
+        "metro-babel-transformer": "0.83.2",
+        "metro-cache": "0.83.2",
+        "metro-cache-key": "0.83.2",
+        "metro-config": "0.83.2",
+        "metro-core": "0.83.2",
+        "metro-file-map": "0.83.2",
+        "metro-resolver": "0.83.2",
+        "metro-runtime": "0.83.2",
+        "metro-source-map": "0.83.2",
+        "metro-transform-plugins": "0.83.2",
+        "metro-transform-worker": "0.83.2"
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "54.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.6.tgz",
-      "integrity": "sha512-z3wufTr1skM03PI6Dr1ZsrvjAiGKf/w0VQvdZL+mEnKNqRA7Q4bhJDGk1+nzs+WWRWz4vS488uad9ERmSclBmg==",
+      "version": "54.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.9.tgz",
+      "integrity": "sha512-CRI4WgFXrQ2Owyr8q0liEBJveUIF9DcYAKadMRsJV7NxGNBdrIIKzKvqreDfsGiRqivbLsw6UoNb3UE7/SvPfg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -6233,7 +6233,7 @@
         "@expo/config": "~12.0.10",
         "@expo/env": "~2.0.7",
         "@expo/json-file": "~10.0.7",
-        "@expo/metro": "~54.0.0",
+        "@expo/metro": "~54.1.0",
         "@expo/spawn-async": "^1.7.2",
         "browserslist": "^4.25.0",
         "chalk": "^4.1.0",
@@ -6622,9 +6622,9 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "54.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.5.tgz",
-      "integrity": "sha512-eCvbVUf01j1nSrs4mG/rWwY+SfgE30LM6JcElLrnNgNnaDWzt09E/c8n3ZeTLNKENwJaQQ1KIn2VE461/4VnWQ==",
+      "version": "54.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.6.tgz",
+      "integrity": "sha512-xowuMmyPNy+WTNq+YX0m0EFO/Knc68swjThk4dKivgZa8zI1UjvFXOBIOp8RX4ljCXLzwxQJM5oBBTvyn+59ZA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -6634,7 +6634,7 @@
         "@expo/config-types": "^54.0.8",
         "@expo/image-utils": "^0.8.7",
         "@expo/json-file": "^10.0.7",
-        "@react-native/normalize-colors": "0.81.4",
+        "@react-native/normalize-colors": "0.81.5",
         "debug": "^4.3.1",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0",
@@ -6694,9 +6694,9 @@
       "peer": true
     },
     "node_modules/@expo/vector-icons": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.0.2.tgz",
-      "integrity": "sha512-IiBjg7ZikueuHNf40wSGCf0zS73a3guJLdZzKnDUxsauB8VWPLMeWnRIupc+7cFhLUkqyvyo0jLNlcxG5xPOuQ==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.0.3.tgz",
+      "integrity": "sha512-SBUyYKphmlfUBqxSfDdJ3jAdEVSALS2VUPOUyqn48oZmb2TL/O7t7/PQm5v4NQujYEPLPMTLn9KVw6H7twwbTA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9531,19 +9531,19 @@
       }
     },
     "node_modules/@polkadot/api-contract": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-16.4.8.tgz",
-      "integrity": "sha512-xgwXXRpalZTjn7O5BKquJ/gQLhTSrz74G/37YgLDfpQd5QrBSuHdK//0wSNsdNJdefxaOx6HovTdSDGheVpj6w==",
+      "version": "16.4.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-16.4.9.tgz",
+      "integrity": "sha512-a2EQTsdW+yqLew00bgl1w3oMteTeQ4wt+JnKjX70uyU/07aw7yrxlk8gwVo3SmzS1yHDEXEagpxwB6SlWq10SQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@polkadot/api": "16.4.8",
-        "@polkadot/api-augment": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/types-create": "16.4.8",
-        "@polkadot/util": "^13.5.6",
-        "@polkadot/util-crypto": "^13.5.6",
+        "@polkadot/api": "16.4.9",
+        "@polkadot/api-augment": "16.4.9",
+        "@polkadot/types": "16.4.9",
+        "@polkadot/types-codec": "16.4.9",
+        "@polkadot/types-create": "16.4.9",
+        "@polkadot/util": "^13.5.7",
+        "@polkadot/util-crypto": "^13.5.7",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -9552,18 +9552,33 @@
       }
     },
     "node_modules/@polkadot/api-contract/node_modules/@polkadot/api-augment": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.4.8.tgz",
-      "integrity": "sha512-hBjSCkQjKqfUmhD1eNFg01Q1kivD5EGnq7zCaKFof+2Y1pdCs9EI5Qa+7MLJFJA0TvHBY6ILt5mSW6Gp/b0dtw==",
+      "version": "16.4.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.4.9.tgz",
+      "integrity": "sha512-3C5g6VUjs3cOwZmI2QDxZnwyLXI7554+fxQ/Mi5q12l7/5D5UrvDcDxFKUMALEUJRixGUvQ5T0f8s4mTHO/QsQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@polkadot/api-base": "16.4.8",
-        "@polkadot/rpc-augment": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-augment": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/api-base": "16.4.9",
+        "@polkadot/rpc-augment": "16.4.9",
+        "@polkadot/types": "16.4.9",
+        "@polkadot/types-augment": "16.4.9",
+        "@polkadot/types-codec": "16.4.9",
+        "@polkadot/util": "^13.5.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-contract/node_modules/@polkadot/api-augment/node_modules/@polkadot/types-codec": {
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.4.3.tgz",
+      "integrity": "sha512-tsezTQwwf6dnCK9ShKt3HbzTH+8nWYYhdcExwx90PYIXUmMb0zbK5bfVLSyh1VvcSy6a9TeBR/AiL6n8/c5gDg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "^13.5.4",
+        "@polkadot/x-bigint": "^13.5.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -9571,16 +9586,31 @@
       }
     },
     "node_modules/@polkadot/api-contract/node_modules/@polkadot/rpc-augment": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.4.8.tgz",
-      "integrity": "sha512-ri5yjmVa0zw56nVQr2P0ozxxz89+RwBUD01sgusNraRbrYOCpNyJlOUsom/1qTVIylyOknzIxpAgFoMkALuqwg==",
+      "version": "16.4.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.4.9.tgz",
+      "integrity": "sha512-J/6A2NgM92K8vHKGqUo877dPEOzYDoAm/8Ixrbq64obYnaVl5kAN+cctyRR0ywOTrY1wyRJmVa6Y83IPMgbX/A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@polkadot/rpc-core": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/rpc-core": "16.4.9",
+        "@polkadot/types": "16.4.9",
+        "@polkadot/types-codec": "16.4.9",
+        "@polkadot/util": "^13.5.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-contract/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/types-codec": {
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.4.3.tgz",
+      "integrity": "sha512-tsezTQwwf6dnCK9ShKt3HbzTH+8nWYYhdcExwx90PYIXUmMb0zbK5bfVLSyh1VvcSy6a9TeBR/AiL6n8/c5gDg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "^13.5.4",
+        "@polkadot/x-bigint": "^13.5.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -9588,16 +9618,16 @@
       }
     },
     "node_modules/@polkadot/api-contract/node_modules/@polkadot/rpc-core": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.4.8.tgz",
-      "integrity": "sha512-LN5BgUeBjGaxybUyFB8WbBU5clwthcMu4XYT0vN4howx/3BvJgBPMvm+K52eWdzSWlPojGtVkNNCy9QTNFWx0w==",
+      "version": "16.4.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.4.9.tgz",
+      "integrity": "sha512-yOe0envLjrAffxL5NI1U9XaSt7bst93TVQdOyPw0HKCLc3uCJWnrnq8CKvdmR7IfHop+A1rkLaWyfY3tWcUMrA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@polkadot/rpc-augment": "16.4.8",
-        "@polkadot/rpc-provider": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/rpc-augment": "16.4.9",
+        "@polkadot/rpc-provider": "16.4.9",
+        "@polkadot/types": "16.4.9",
+        "@polkadot/util": "^13.5.7",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -9606,15 +9636,45 @@
       }
     },
     "node_modules/@polkadot/api-contract/node_modules/@polkadot/types-augment": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.4.8.tgz",
-      "integrity": "sha512-oAJ2okk+z210yS8D3Bj51Bgg5c3L2bAnL7PLnXpfcavGJh8cnvWoEi438lhqPuLKNrTnMw9qrnxH+YRLqRGhqA==",
+      "version": "16.4.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.4.9.tgz",
+      "integrity": "sha512-uTl3kJ01v3POJzIruzVtWshWjpd8nUmeREE0FSyYS6nb99mEk3nVy3w6V3dsHjEBF2X7FdU2ePTbr9mK0MI5AA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/types": "16.4.9",
+        "@polkadot/types-codec": "16.4.9",
+        "@polkadot/util": "^13.5.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-contract/node_modules/@polkadot/types-augment/node_modules/@polkadot/types-codec": {
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.4.3.tgz",
+      "integrity": "sha512-tsezTQwwf6dnCK9ShKt3HbzTH+8nWYYhdcExwx90PYIXUmMb0zbK5bfVLSyh1VvcSy6a9TeBR/AiL6n8/c5gDg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "^13.5.4",
+        "@polkadot/x-bigint": "^13.5.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-contract/node_modules/@polkadot/types-codec": {
+      "version": "16.4.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.4.9.tgz",
+      "integrity": "sha512-yw03qNA1QlXhvQ1zPE/+Km0t4tU3505chWJgR7m8sDehQkKXF0rNYURPuAVE+LpkzSyacJr9KU1X4Nkg42VfuQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "^13.5.7",
+        "@polkadot/x-bigint": "^13.5.7",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -9622,15 +9682,57 @@
       }
     },
     "node_modules/@polkadot/api-contract/node_modules/@polkadot/types-create": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.4.8.tgz",
-      "integrity": "sha512-YpI+yv8tsyV1Psn5KjPbAOmZ+KwrmYRxQD1GIbo72LbsEV0mCfELsKJiJLT16xgIe4JaWDKOu4ofgHV42cBmUg==",
+      "version": "16.4.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.4.9.tgz",
+      "integrity": "sha512-428fwkPmQnENZdbX8bmc4dSqkVm328c1/Byxaa67gNsexeYi3XCFqjFC4toDECHNWW2YYN0XuPK6ieunPZuFpQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/types-codec": "16.4.9",
+        "@polkadot/util": "^13.5.7",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-contract/node_modules/@polkadot/types-create/node_modules/@polkadot/types-codec": {
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.4.3.tgz",
+      "integrity": "sha512-tsezTQwwf6dnCK9ShKt3HbzTH+8nWYYhdcExwx90PYIXUmMb0zbK5bfVLSyh1VvcSy6a9TeBR/AiL6n8/c5gDg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "^13.5.4",
+        "@polkadot/x-bigint": "^13.5.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-contract/node_modules/@polkadot/x-bigint": {
+      "version": "13.5.7",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.7.tgz",
+      "integrity": "sha512-NbN4EPbMBhjOXoWj0BVcT49/obzusFWPKbSyBxbZi8ITBaIIgpncgcCfXY4rII6Fqh74khx9jdevWge/6ycepQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "13.5.7",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-contract/node_modules/@polkadot/x-global": {
+      "version": "13.5.7",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.7.tgz",
+      "integrity": "sha512-TkBxLfeKtj0laCzXp2lvRhwSIeXSxIu7LAWpfAUW4SYNFQvtgIS0x0Bq70CUW3lcy0wqTrSG2cqzfnbomB0Djw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
@@ -10304,6 +10406,33 @@
         "@rollup/rollup-linux-x64-gnu": "^4.44.1"
       }
     },
+    "node_modules/@projectlibertylabs/siwfv2/node_modules/@polkadot/types-codec": {
+      "version": "16.4.8",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.4.8.tgz",
+      "integrity": "sha512-JMaXwnaZUwpgHqdpU7zRh2HtDDzMDwYK0qHK5p1UhDK3eArq3rYLUsCvLatC8tNaZUB4wHHBIbG0qSslWHDf+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^13.5.6",
+        "@polkadot/x-bigint": "^13.5.6",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@projectlibertylabs/siwfv2/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -10369,9 +10498,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.82.0.tgz",
-      "integrity": "sha512-SHRZxH+VHb6RwcHNskxyjso6o91Lq0DPgOpE5cDrppn1ziYhI723rjufFgh59RcpH441eci0/cXs/b0csXTtnw==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.82.1.tgz",
+      "integrity": "sha512-B1SRwpntaAcckiatxbjzylvNK562Ayza05gdJCjDQHTiDafa1OABmyB5LHt7qWDOpNkaluD+w11vHF7pBmTpzQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -10380,24 +10509,24 @@
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.4.tgz",
-      "integrity": "sha512-6ztXf2Tl2iWznyI/Da/N2Eqymt0Mnn69GCLnEFxFbNdk0HxHPZBNWU9shTXhsLWOL7HATSqwg/bB1+3kY1q+mA==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.5.tgz",
+      "integrity": "sha512-oF71cIH6je3fSLi6VPjjC3Sgyyn57JLHXs+mHWc9MoCiJJcM4nqsS5J38zv1XQ8d3zOW2JtHro+LF0tagj2bfQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.81.4"
+        "@react-native/codegen": "0.81.5"
       },
       "engines": {
         "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.81.4.tgz",
-      "integrity": "sha512-VYj0c/cTjQJn/RJ5G6P0L9wuYSbU9yGbPYDHCKstlQZQWkk+L9V8ZDbxdJBTIei9Xl3KPQ1odQ4QaeW+4v+AZg==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.81.5.tgz",
+      "integrity": "sha512-UoI/x/5tCmi+pZ3c1+Ypr1DaRMDLI3y+Q70pVLLVgrnC3DHsHRIbHcCHIeG/IJvoeFqFM2sTdhSOLJrf8lOPrA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -10443,7 +10572,7 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.81.4",
+        "@react-native/babel-plugin-codegen": "0.81.5",
         "babel-plugin-syntax-hermes-parser": "0.29.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
@@ -10456,9 +10585,9 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.4.tgz",
-      "integrity": "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.5.tgz",
+      "integrity": "sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -10502,14 +10631,14 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.82.0.tgz",
-      "integrity": "sha512-n5dxQowsRAjruG5sNl6MEPUzANUiVERaL7w4lHGmm/pz/ey1JOM9sFxL6RpZp1FJSVu4QKmbx6sIHrKb2MCekg==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.82.1.tgz",
+      "integrity": "sha512-H/eMdtOy9nEeX7YVeEG1N2vyCoifw3dr9OV8++xfUElNYV7LtSmJ6AqxZUUfxGJRDFPQvaU/8enmJlM/l11VxQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@react-native/dev-middleware": "0.82.0",
+        "@react-native/dev-middleware": "0.82.1",
         "debug": "^4.4.0",
         "invariant": "^2.2.4",
         "metro": "^0.83.1",
@@ -10534,9 +10663,9 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.82.0.tgz",
-      "integrity": "sha512-rlTDcjf0ecjOHmygdBACAQCqPG0z/itAxnbhk8ZiQts7m4gRJiA/iCGFyC8/T9voUA0azAX6QCl4tHlnuUy7mQ==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.82.1.tgz",
+      "integrity": "sha512-a2O6M7/OZ2V9rdavOHyCQ+10z54JX8+B+apYKCQ6a9zoEChGTxUMG2YzzJ8zZJVvYf1ByWSNxv9Se0dca1hO9A==",
       "license": "BSD-3-Clause",
       "optional": true,
       "peer": true,
@@ -10545,16 +10674,16 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.82.0.tgz",
-      "integrity": "sha512-SHvpo89RSzH06yZCmY3Xwr1J82EdUljC2lcO4YvXfHmytFG453Nz6kyZQcDEqGCfWDjznIUFUyT2UcLErmRWQg==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.82.1.tgz",
+      "integrity": "sha512-wuOIzms/Qg5raBV6Ctf2LmgzEOCqdP3p1AYN4zdhMT110c39TVMbunpBaJxm0Kbt2HQ762MQViF9naxk7SBo4w==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.82.0",
-        "@react-native/debugger-shell": "0.82.0",
+        "@react-native/debugger-frontend": "0.82.1",
+        "@react-native/debugger-shell": "0.82.1",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
@@ -10690,9 +10819,9 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.81.4.tgz",
-      "integrity": "sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.81.5.tgz",
+      "integrity": "sha512-bnd9FSdWKx2ncklOetCgrlwqSGhMHP2zOxObJbOWXoj7GHEmih4MKarBo5/a8gX8EfA1EwRATdfNBQ81DY+h+w==",
       "license": "BSD-3-Clause",
       "optional": true,
       "peer": true,
@@ -10701,9 +10830,9 @@
       }
     },
     "node_modules/@react-native/debugger-shell": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.82.0.tgz",
-      "integrity": "sha512-XbXABIMzaH7SvapNWcW+zix1uHeSX/MoXYKKWWTs99a12TgwNuTeLKKTEj/ZkAjWtaCCqb/sMI4aJDLXKppCGg==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.82.1.tgz",
+      "integrity": "sha512-fdRHAeqqPT93bSrxfX+JHPpCXHApfDUdrXMXhoxlPgSzgXQXJDykIViKhtpu0M6slX6xU/+duq+AtP/qWJRpBw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -10716,15 +10845,15 @@
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.81.4.tgz",
-      "integrity": "sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.81.5.tgz",
+      "integrity": "sha512-WfPfZzboYgo/TUtysuD5xyANzzfka8Ebni6RIb2wDxhb56ERi7qDrE4xGhtPsjCL4pQBXSVxyIlCy0d8I6EgGA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.81.4",
+        "@react-native/debugger-frontend": "0.81.5",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
@@ -10860,9 +10989,9 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.82.0.tgz",
-      "integrity": "sha512-PTfmQ6cYsJgMXJ49NzB4Sz/DmRUtwatGtcA6MuskRvQpSinno/00Sns7wxphkTVMHGAwk3Xh0t0SFNd1d1HCyw==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.82.1.tgz",
+      "integrity": "sha512-KkF/2T1NSn6EJ5ALNT/gx0MHlrntFHv8YdooH9OOGl9HQn5NM0ZmQSr86o5utJsGc7ME3R6p3SaQuzlsFDrn8Q==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -10871,9 +11000,9 @@
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.82.0.tgz",
-      "integrity": "sha512-7K1K64rfq0sKoGxB2DTsZROxal0B04Q+ftia0JyCOGOto/tyBQIQqiQgVtMVEBZSEXZyXmGx3HzF4EEPlvrEtw==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.82.1.tgz",
+      "integrity": "sha512-tf70X7pUodslOBdLN37J57JmDPB/yiZcNDzS2m+4bbQzo8fhx3eG9QEBv5n4fmzqfGAgSB4BWRHgDMXmmlDSVA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -10882,17 +11011,17 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.81.4",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.4.tgz",
-      "integrity": "sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg==",
+      "version": "0.81.5",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",
+      "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
       "license": "MIT",
       "optional": true,
       "peer": true
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.82.0.tgz",
-      "integrity": "sha512-fReDITtqwWdN29doPHhmeQEqa12ATJ4M2Y1MrT8Q1Hoy5a0H3oEn9S7fknGr7Pj+/I77yHyJajUbCupnJ8vkFA==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.82.1.tgz",
+      "integrity": "sha512-f5zpJg9gzh7JtCbsIwV+4kP3eI0QBuA93JGmwFRd4onQ3DnCjV2J5pYqdWtM95sjSKK1dyik59Gj01lLeKqs1Q==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -14612,9 +14741,9 @@
       }
     },
     "node_modules/babel-plugin-react-native-web": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.21.1.tgz",
-      "integrity": "sha512-7XywfJ5QIRMwjOL+pwJt2w47Jmi5fFLvK7/So4fV4jIN6PcRbylCp9/l3cJY4VJbSz3lnWTeHDTD1LKIc1C09Q==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.21.2.tgz",
+      "integrity": "sha512-SPD0J6qjJn8231i0HZhlAGH6NORe+QvRSQM2mwQEzJ2Fb3E4ruWTiiicPlHjmeWShDXLcvoorOCXjeR7k/lyWA==",
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -14669,9 +14798,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "54.0.4",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.4.tgz",
-      "integrity": "sha512-0/1/xh2m/G4FSvIbJYcu5TGPfDrHRqmIDoAFm6zWSEuWyCDagZ8gjjTTJqxdNJHvsKQl65PzeXd6Q5k6tF57wA==",
+      "version": "54.0.7",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.7.tgz",
+      "integrity": "sha512-JENWk0bvxW4I1ftveO8GRtX2t2TH6N4Z0TPvIHxroZ/4SswUfyNsUNbbP7Fm4erj3ar/JHGri5kTZ+s3xdjHZw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -14691,7 +14820,7 @@
         "@babel/plugin-transform-runtime": "^7.24.7",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.81.4",
+        "@react-native/babel-preset": "0.81.5",
         "babel-plugin-react-compiler": "^1.0.0",
         "babel-plugin-react-native-web": "~0.21.0",
         "babel-plugin-syntax-hermes-parser": "^0.29.1",
@@ -15830,45 +15959,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "callsites": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-callsite/node_modules/callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "caller-callsite": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/callsites": {
@@ -19864,31 +19954,31 @@
       }
     },
     "node_modules/expo": {
-      "version": "54.0.13",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.13.tgz",
-      "integrity": "sha512-F1puKXzw8ESnsbvaKdXtcIiyYLQ2kUHqP8LuhgtJS1wm6w55VhtOPg8yl/0i8kPbTA0YfD+KYdXjSfhPXgUPxw==",
+      "version": "54.0.23",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.23.tgz",
+      "integrity": "sha512-b4uQoiRwQ6nwqsT2709RS15CWYNGF3eJtyr1KyLw9WuMAK7u4jjofkhRiO0+3o1C2NbV+WooyYTOZGubQQMBaQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.11",
+        "@expo/cli": "54.0.16",
         "@expo/config": "~12.0.10",
         "@expo/config-plugins": "~54.0.2",
         "@expo/devtools": "0.1.7",
-        "@expo/fingerprint": "0.15.1",
-        "@expo/metro": "~54.0.0",
-        "@expo/metro-config": "54.0.6",
-        "@expo/vector-icons": "^15.0.2",
+        "@expo/fingerprint": "0.15.3",
+        "@expo/metro": "~54.1.0",
+        "@expo/metro-config": "54.0.9",
+        "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~54.0.3",
+        "babel-preset-expo": "~54.0.7",
         "expo-asset": "~12.0.9",
-        "expo-constants": "~18.0.9",
+        "expo-constants": "~18.0.10",
         "expo-file-system": "~19.0.17",
         "expo-font": "~14.0.9",
         "expo-keep-awake": "~15.0.7",
-        "expo-modules-autolinking": "3.0.15",
-        "expo-modules-core": "3.0.21",
+        "expo-modules-autolinking": "3.0.21",
+        "expo-modules-core": "3.0.25",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -19935,14 +20025,14 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "18.0.9",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.9.tgz",
-      "integrity": "sha512-sqoXHAOGDcr+M9NlXzj1tGoZyd3zxYDy215W6E0Z0n8fgBaqce9FAYQE2bu5X4G629AYig5go7U6sQz7Pjcm8A==",
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.10.tgz",
+      "integrity": "sha512-Rhtv+X974k0Cahmvx6p7ER5+pNhBC0XbP1lRviL2J1Xl4sT2FBaIuIxF/0I0CbhOsySf0ksqc5caFweAy9Ewiw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@expo/config": "~12.0.9",
+        "@expo/config": "~12.0.10",
         "@expo/env": "~2.0.7"
       },
       "peerDependencies": {
@@ -20059,9 +20149,9 @@
       }
     },
     "node_modules/expo-server": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.1.tgz",
-      "integrity": "sha512-J3JlpzNXOkkr4BbapTrcv6klBQcw6NzrBBVIU7qkNE2eU3U1on9rp27wi0+cihjG/QgxSIqQVkrga5z3HWnH0A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.4.tgz",
+      "integrity": "sha512-IN06r3oPxFh3plSXdvBL7dx0x6k+0/g0bgxJlNISs6qL5Z+gyPuWS750dpTzOeu37KyBG0RcyO9cXUKzjYgd4A==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -20105,17 +20195,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/expo/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/expo/node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -20128,9 +20207,9 @@
       }
     },
     "node_modules/expo/node_modules/expo-modules-autolinking": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.15.tgz",
-      "integrity": "sha512-B6c+x664ImrWd+PknEy5454gtY6P0cMxj4P50fvLYP4HimbYj9SzwoHqZ/Rxh9NwxnUkT2nappk/USYIcPoS/A==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.21.tgz",
+      "integrity": "sha512-pOtPDLln3Ju8DW1zRW4OwZ702YqZ8g+kM/tEY1sWfv22kWUtxkvK+ytRDRpRdnKEnC28okbhWqeMnmVkSFzP6Q==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -20138,7 +20217,6 @@
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.1.0",
         "commander": "^7.2.0",
-        "glob": "^10.4.2",
         "require-from-string": "^2.0.2",
         "resolve-from": "^5.0.0"
       },
@@ -20147,9 +20225,9 @@
       }
     },
     "node_modules/expo/node_modules/expo-modules-core": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.21.tgz",
-      "integrity": "sha512-KJRzm0FEt/lfPNG+C6UUq+ta9PO10QPwY1HGCNkzPiRCIMJmQP4xRYK4Z7AxiYEYsPqr5OdjRW55kGZ4c5pzgA==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.25.tgz",
+      "integrity": "sha512-0P8PT8UV6c5/+p8zeVM/FXvBgn/ErtGcMaasqUgbzzBUg94ktbkIrij9t9reGCrir03BYt/Bcpv+EQtYC8JOug==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -20159,88 +20237,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/expo/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/expo/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/expo/node_modules/pretty-format": {
@@ -20271,9 +20267,9 @@
       }
     },
     "node_modules/exponential-backoff": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
-      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true
@@ -23418,17 +23414,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -25399,7 +25384,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -25762,9 +25747,9 @@
       }
     },
     "node_modules/ky": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-1.11.0.tgz",
-      "integrity": "sha512-NEyo0ICpS0cqSuyoJFMCnHOZJILqXsKhIZlHJGDYaH8OB5IFrGzuBpEwyoMZG6gUKMPrazH30Ax5XKaujvD8ag==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.13.0.tgz",
+      "integrity": "sha512-JeNNGs44hVUp2XxO3FY9WV28ymG7LgO4wju4HL/dCq1A8eKDcFgVrdCn1ssn+3Q/5OQilv5aYsL0DMt5mmAV9w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -27141,9 +27126,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.1.tgz",
-      "integrity": "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.2.tgz",
+      "integrity": "sha512-HQgs9H1FyVbRptNSMy/ImchTTE5vS2MSqLoOo7hbDoBq6hPPZokwJvBMwrYSxdjQZmLXz2JFZtdvS+ZfgTc9yw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27163,24 +27148,24 @@
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.29.1",
+        "hermes-parser": "0.32.0",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.83.1",
-        "metro-cache": "0.83.1",
-        "metro-cache-key": "0.83.1",
-        "metro-config": "0.83.1",
-        "metro-core": "0.83.1",
-        "metro-file-map": "0.83.1",
-        "metro-resolver": "0.83.1",
-        "metro-runtime": "0.83.1",
-        "metro-source-map": "0.83.1",
-        "metro-symbolicate": "0.83.1",
-        "metro-transform-plugins": "0.83.1",
-        "metro-transform-worker": "0.83.1",
+        "metro-babel-transformer": "0.83.2",
+        "metro-cache": "0.83.2",
+        "metro-cache-key": "0.83.2",
+        "metro-config": "0.83.2",
+        "metro-core": "0.83.2",
+        "metro-file-map": "0.83.2",
+        "metro-resolver": "0.83.2",
+        "metro-runtime": "0.83.2",
+        "metro-source-map": "0.83.2",
+        "metro-symbolicate": "0.83.2",
+        "metro-transform-plugins": "0.83.2",
+        "metro-transform-worker": "0.83.2",
         "mime-types": "^2.1.27",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -27197,26 +27182,45 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.1.tgz",
-      "integrity": "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.2.tgz",
+      "integrity": "sha512-rirY1QMFlA1uxH3ZiNauBninwTioOgwChnRdDcbB4tgRZ+bGX9DiXoh9QdpppiaVKXdJsII932OwWXGGV4+Nlw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.29.1",
+        "hermes-parser": "0.32.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
+    "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.32.0"
+      }
+    },
     "node_modules/metro-cache": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.1.tgz",
-      "integrity": "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.2.tgz",
+      "integrity": "sha512-Z43IodutUZeIS7OTH+yQFjc59QlFJ6s5OvM8p2AP9alr0+F8UKr8ADzFzoGKoHefZSKGa4bJx7MZJLF6GwPDHQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27224,16 +27228,16 @@
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.83.1"
+        "metro-core": "0.83.2"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.1.tgz",
-      "integrity": "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.2.tgz",
+      "integrity": "sha512-3EMG/GkGKYoTaf5RqguGLSWRqGTwO7NQ0qXKmNBjr0y6qD9s3VBXYlwB+MszGtmOKsqE9q3FPrE5Nd9Ipv7rZw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27245,21 +27249,21 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.1.tgz",
-      "integrity": "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.2.tgz",
+      "integrity": "sha512-1FjCcdBe3e3D08gSSiU9u3Vtxd7alGH3x/DNFqWDFf5NouX4kLgbVloDDClr1UrLz62c0fHh2Vfr9ecmrOZp+g==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "connect": "^3.6.5",
-        "cosmiconfig": "^5.0.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.83.1",
-        "metro-cache": "0.83.1",
-        "metro-core": "0.83.1",
-        "metro-runtime": "0.83.1"
+        "metro": "0.83.2",
+        "metro-cache": "0.83.2",
+        "metro-core": "0.83.2",
+        "metro-runtime": "0.83.2",
+        "yaml": "^2.6.1"
       },
       "engines": {
         "node": ">=20.19.4"
@@ -27320,17 +27324,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/metro-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/metro-config/node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -27343,38 +27336,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/metro-config/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-config/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/metro-config/node_modules/jest-validate": {
@@ -27396,21 +27357,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/metro-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/metro-config/node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -27420,21 +27366,6 @@
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/metro-config/node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/metro-config/node_modules/pretty-format": {
@@ -27453,45 +27384,26 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/metro-config/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-config/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/metro-core": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.1.tgz",
-      "integrity": "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.2.tgz",
+      "integrity": "sha512-8DRb0O82Br0IW77cNgKMLYWUkx48lWxUkvNUxVISyMkcNwE/9ywf1MYQUE88HaKwSrqne6kFgCSA/UWZoUT0Iw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.83.1"
+        "metro-resolver": "0.83.2"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.1.tgz",
-      "integrity": "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.2.tgz",
+      "integrity": "sha512-cMSWnEqZrp/dzZIEd7DEDdk72PXz6w5NOKriJoDN9p1TDQ5nAYrY2lHi8d6mwbcGLoSlWmpPyny9HZYFfPWcGQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27619,9 +27531,9 @@
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.1.tgz",
-      "integrity": "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.2.tgz",
+      "integrity": "sha512-zvIxnh7U0JQ7vT4quasKsijId3dOAWgq+ip2jF/8TMrPUqQabGrs04L2dd0haQJ+PA+d4VvK/bPOY8X/vL2PWw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27634,9 +27546,9 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.1.tgz",
-      "integrity": "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.2.tgz",
+      "integrity": "sha512-Yf5mjyuiRE/Y+KvqfsZxrbHDA15NZxyfg8pIk0qg47LfAJhpMVEX+36e6ZRBq7KVBqy6VDX5Sq55iHGM4xSm7Q==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27648,9 +27560,9 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.1.tgz",
-      "integrity": "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.2.tgz",
+      "integrity": "sha512-nnsPtgRvFbNKwemqs0FuyFDzXLl+ezuFsUXDbX8o0SXOfsOPijqiQrf3kuafO1Zx1aUWf4NOrKJMAQP5EEHg9A==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27663,9 +27575,9 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.1.tgz",
-      "integrity": "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.2.tgz",
+      "integrity": "sha512-5FL/6BSQvshIKjXOennt9upFngq2lFvDakZn5LfauIVq8+L4sxXewIlSTcxAtzbtjAIaXeOSVMtCJ5DdfCt9AA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27675,9 +27587,9 @@
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.83.1",
+        "metro-symbolicate": "0.83.2",
         "nullthrows": "^1.1.1",
-        "ob1": "0.83.1",
+        "ob1": "0.83.2",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -27697,16 +27609,16 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.1.tgz",
-      "integrity": "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.2.tgz",
+      "integrity": "sha512-KoU9BLwxxED6n33KYuQQuc5bXkIxF3fSwlc3ouxrrdLWwhu64muYZNQrukkWzhVKRNFIXW7X2iM8JXpi2heIPw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.83.1",
+        "metro-source-map": "0.83.2",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -27730,9 +27642,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.1.tgz",
-      "integrity": "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.2.tgz",
+      "integrity": "sha512-5WlW25WKPkiJk2yA9d8bMuZrgW7vfA4f4MBb9ZeHbTB3eIAoNN8vS8NENgG/X/90vpTB06X66OBvxhT3nHwP6A==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27749,9 +27661,9 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.1.tgz",
-      "integrity": "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.2.tgz",
+      "integrity": "sha512-G5DsIg+cMZ2KNfrdLnWMvtppb3+Rp1GMyj7Bvd9GgYc/8gRmvq1XVEF9XuO87Shhb03kFhGqMTgZerz3hZ1v4Q==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -27761,13 +27673,13 @@
         "@babel/parser": "^7.25.3",
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.83.1",
-        "metro-babel-transformer": "0.83.1",
-        "metro-cache": "0.83.1",
-        "metro-cache-key": "0.83.1",
-        "metro-minify-terser": "0.83.1",
-        "metro-source-map": "0.83.1",
-        "metro-transform-plugins": "0.83.1",
+        "metro": "0.83.2",
+        "metro-babel-transformer": "0.83.2",
+        "metro-cache": "0.83.2",
+        "metro-cache-key": "0.83.2",
+        "metro-minify-terser": "0.83.2",
+        "metro-source-map": "0.83.2",
+        "metro-transform-plugins": "0.83.2",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -27837,6 +27749,25 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/metro/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/metro/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.32.0"
+      }
     },
     "node_modules/metro/node_modules/jest-util": {
       "version": "29.7.0",
@@ -30963,9 +30894,9 @@
       }
     },
     "node_modules/ob1": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.1.tgz",
-      "integrity": "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ==",
+      "version": "0.83.2",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.2.tgz",
+      "integrity": "sha512-XlK3w4M+dwd1g1gvHzVbxiXEbUllRONEgcF2uEO0zm4nxa0eKlh41c6N65q1xbiDOeKKda1tvNOAD33fNjyvCg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -33413,21 +33344,21 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.82.0.tgz",
-      "integrity": "sha512-E+sBFDgpwzoZzPn86gSGRBGLnS9Q6r4y6Xk5I57/QbkqkDOxmQb/bzQq/oCdUCdHImKiow2ldC3WJfnvAKIfzg==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.82.1.tgz",
+      "integrity": "sha512-tFAqcU7Z4g49xf/KnyCEzI4nRTu1Opcx05Ov2helr8ZTg1z7AJR/3sr2rZ+AAVlAs2IXk+B0WOxXGmdD3+4czA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.82.0",
-        "@react-native/codegen": "0.82.0",
-        "@react-native/community-cli-plugin": "0.82.0",
-        "@react-native/gradle-plugin": "0.82.0",
-        "@react-native/js-polyfills": "0.82.0",
-        "@react-native/normalize-colors": "0.82.0",
-        "@react-native/virtualized-lists": "0.82.0",
+        "@react-native/assets-registry": "0.82.1",
+        "@react-native/codegen": "0.82.1",
+        "@react-native/community-cli-plugin": "0.82.1",
+        "@react-native/gradle-plugin": "0.82.1",
+        "@react-native/js-polyfills": "0.82.1",
+        "@react-native/normalize-colors": "0.82.1",
+        "@react-native/virtualized-lists": "0.82.1",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -33601,9 +33532,9 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.82.0.tgz",
-      "integrity": "sha512-DJKDwyr6s0EtoPKmAaOsx2EnS2sV/qICNWn/KA+8lohSY6gJF1wuA+DOjitivBfU0soADoo8tqGq50C5rlzmCA==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.82.1.tgz",
+      "integrity": "sha512-ezXTN70ygVm9l2m0i+pAlct0RntoV4afftWMGUIeAWLgaca9qItQ54uOt32I/9dBJvzBibT33luIR/pBG0dQvg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -33624,9 +33555,9 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.82.0.tgz",
-      "integrity": "sha512-oinsK6TYEz5RnFTSk9P+hJ/N/E0pOG76O0euU0Gf3BlXArDpS8m3vrGcTjqeQvajRIaYVHIRAY9hCO6q+exyLg==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.82.1.tgz",
+      "integrity": "sha512-CCfTR1uX+Z7zJTdt3DNX9LUXr2zWXsNOyLbwupW2wmRzrxlHRYfmLgTABzRL/cKhh0Ubuwn15o72MQChvCRaHw==",
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -37349,10 +37280,10 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "peer": true
     },


### PR DESCRIPTION
# Purpose
The goal of this PR is to do some minor housekeeping brought on by the v3/content/batchAnnouncement endpoint being missing from the Swagger docs.

## Changes
* separate the v3/content/batchAnnouncement e2e tests
* update/regen the swagger openapi-specs for above
* update the PR template to remind ourselves to do so
* minor version update for babel

## To verify:
The main thing is to launch content publishing api and verify that the v3 endpoint shows up in the Swagger docs.

### Checklist
- [x] Integration/end-to-end tests **updated**
- [x] Documentation added or updated (where applicable)
- [x] API endpoints added or changed? Swagger docs regenerated
