### PR TITLE
fix: build correct SCALE payload for paginated upsert in account service

### DIFF
--- a/apps/account-api/src/controllers/v1/ics.controller.v1.spec.ts
+++ b/apps/account-api/src/controllers/v1/ics.controller.v1.spec.ts
@@ -46,6 +46,7 @@ describe('IcsController', () => {
             getApi: () => mockApiPromise,
             publicKeyToMsaId: jest.fn(),
             createItemizedSignaturePayloadV2Type: jest.fn().mockImplementation(() => Uint8Array.from([1, 2, 3])),
+            createPaginatedUpsertSignaturePayloadV2Type: jest.fn().mockImplementation(() => Uint8Array.from([1, 2, 3])),
           };
         }
         if (token === EnqueueService) {

--- a/apps/account-api/src/controllers/v1/ics.controller.v1.ts
+++ b/apps/account-api/src/controllers/v1/ics.controller.v1.ts
@@ -54,7 +54,11 @@ export class IcsControllerV1 {
     payload: UpsertPagePayloadDto,
     api: ApiPromise,
   ): SubmittableExtrinsic<'promise', ISubmittableResult> {
-    return api.tx.statefulStorage.upsertPageWithSignatureV2(accountId, { Sr25519: payload.signature }, payload.payload);
+    const encodedPayload = this.blockchainService.createPaginatedUpsertSignaturePayloadV2Type(payload.payload);
+    return api.tx.statefulStorage.upsertPageWithSignatureV2(
+      accountId,
+      chainSignature({ algo: 'Sr25519', encodedValue: payload.signature }),
+      encodedPayload);
   }
 
   async buildAndEnqueueIcsBatchTxns(accountId: string, payloads: IcsPublishAllRequestDto): Promise<string> {

--- a/libs/blockchain/src/blockchain-rpc-query.service.ts
+++ b/libs/blockchain/src/blockchain-rpc-query.service.ts
@@ -23,6 +23,7 @@ import {
   FrameSystemEventRecord,
   PalletCapacityCapacityDetails,
   PalletSchemasSchemaInfo,
+  PalletStatefulStoragePaginatedUpsertSignaturePayloadV2,
 } from '@polkadot/types/lookup';
 import {
   ItemizedStoragePageResponse,
@@ -42,7 +43,8 @@ import {
   PublishHandleRequestDto,
   RetireMsaPayloadResponseDto,
   RevokeDelegationPayloadResponseDto,
-  TransactionData,
+  TransactionData, UpsertedPageDto,
+  UpsertPagePayloadDto,
 } from '#types/dtos/account';
 import { hexToU8a } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';
@@ -611,6 +613,18 @@ export class BlockchainRpcQueryService extends PolkadotApiService {
       targetHash: payload.targetHash,
       expiration: payload.expiration,
       actions,
+    });
+  }
+
+  public createPaginatedUpsertSignaturePayloadV2Type(
+    payload: UpsertedPageDto,
+  ): PalletStatefulStoragePaginatedUpsertSignaturePayloadV2 {
+    return this.api.createType('PalletStatefulStoragePaginatedUpsertSignaturePayloadV2', {
+      schemaId: payload.schemaId,
+      targetHash: payload.targetHash,
+      pageId: payload.pageId,
+      payload: Array.from(hexToU8a(payload.payload)),
+      expiration: payload.expiration,
     });
   }
 

--- a/libs/logger/src/logLevel-common-config.ts
+++ b/libs/logger/src/logLevel-common-config.ts
@@ -33,7 +33,11 @@ export function getPinoTransport() {
 }
 
 const customLogLevel = (req, res, err) => {
-  if (req.url === '/metrics' && res.statusCode < 300) {
+  const requestUrl = req.originalUrl || req.url;
+  const requestPath = (requestUrl || '').split('?')[0];
+  const isHealthPath = /(^|\/)(healthz|livez|readyz)\/?$/.test(requestPath);
+  const isMetricsPath = requestPath === '/metrics';
+  if ((isHealthPath || isMetricsPath) && res.statusCode < 300) {
     return 'silent';
   }
   if (res.statusCode >= 400 && res.statusCode < 500) {

--- a/libs/types/src/dtos/account/ics.request.dto.ts
+++ b/libs/types/src/dtos/account/ics.request.dto.ts
@@ -35,6 +35,7 @@ export class UpsertedPageDto {
    * The block number at which the signed proof will expire
    * @example 1
    */
+  @IsIntValue({ minValue: 0, maxValue: 4_294_967_296 })
   expiration: number;
 
   /*

--- a/libs/utils/src/common/signature.util.ts
+++ b/libs/utils/src/common/signature.util.ts
@@ -71,13 +71,16 @@ export const chainSignature = (signature: {
   | {
       Ecdsa: any;
     } => {
+  const normalizedProof = signature.encodedValue.startsWith('0x')
+    ? signature.encodedValue
+    : `0x${signature.encodedValue}`;
   switch (signature.algo.toLowerCase()) {
     case 'sr25519':
-      return { Sr25519: signature.encodedValue };
+      return { Sr25519: normalizedProof };
     case 'ed25519':
-      return { Ed25519: signature.encodedValue };
+      return { Ed25519: normalizedProof };
     case 'ecdsa':
-      return { Ecdsa: signature.encodedValue };
+      return { Ecdsa: normalizedProof };
     default:
       throw new Error(`Unknown signature algorithm: ${signature.algo}`);
   }


### PR DESCRIPTION
# Description
- Add function in `BlockchainRpcQueryService` to build a proper SCALE payload for `upsertPaginatedSignatureV2` extrinsic
- Only log health endpoints if unhealthy to reduce chattiness
- 
Closes #1026 