### PR TITLE
feat: make payloads optional in publishAll endpoint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@ A short description of what you have done to implement/fix the above mentioned f
 @ any other developers who worked on the PR with you
 
 ### Change summary
+
 A general summary of the changes.
 
 ### Steps to Verify
@@ -29,12 +30,11 @@ Delete items that don't apply or mark Not Applicable
 - [ ] API endpoints added or changed? Added the endpoints in main.ts and regenerated Swagger docs
 - [ ] New packages are noted in the description or summary with what they do
 - [ ] Breaking changes? "breaking changes" label added.
-- Environment variable changes? This is a breaking change for deployment:
-    - [ ] Update docker files,  files, environment templates
-    - [ ] Update config Joi validations, and config setup in tests
-    - [ ] Make a pull request for any *-infra repositories with a deployed Gateway instance. Merge this _first_ 
-before merging this PR.
-
+- [ ] Environment variable changes? This is a breaking change for deployment:
+  - [ ] Update docker files, files, environment templates
+  - [ ] Update config Joi validations, and config setup in tests
+  - [ ] Make a pull request for any \*-infra repositories with a deployed Gateway instance. Merge this _first_
+        before merging this PR.
 
 ## Additional details / screenshot
 

--- a/apps/account-api/src/controllers/v1/ics.controller.v1.spec.ts
+++ b/apps/account-api/src/controllers/v1/ics.controller.v1.spec.ts
@@ -72,6 +72,13 @@ describe('IcsController', () => {
   describe('basic', () => {
     const goodAccountId = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
     const mockIcsPublishAllPayload = createIcsPublishAllRequestDto('0x1234');
+    const mockResponse = {
+      status: jest.fn(),
+    } as any;
+
+    beforeEach(() => {
+      mockResponse.status.mockClear();
+    });
 
     beforeAll(() => {
       jest
@@ -86,15 +93,29 @@ describe('IcsController', () => {
 
     it('calls getMsaIdForAccountId', async () => {
       const spy = jest.spyOn(blockchainRpcQueryService, 'publicKeyToMsaId').mockResolvedValueOnce('123');
-      const result = await icsController.publishAll({ accountId: goodAccountId }, mockIcsPublishAllPayload);
+      const result = await icsController.publishAll(
+        { accountId: goodAccountId },
+        mockIcsPublishAllPayload,
+        mockResponse,
+      );
       expect(spy).toHaveBeenCalledWith(goodAccountId);
-      expect(result.referenceId).toBe('referenceId');
+      expect(result).toEqual({ referenceId: 'referenceId' });
+      expect(mockResponse.status).not.toHaveBeenCalled();
+    });
+    it('returns no content when there is nothing to enqueue', async () => {
+      jest.spyOn(blockchainRpcQueryService, 'publicKeyToMsaId').mockResolvedValueOnce('123');
+      jest.spyOn(icsController, 'buildAndEnqueueIcsBatchTxns').mockResolvedValueOnce(null);
+
+      const result = await icsController.publishAll({ accountId: goodAccountId }, {} as any, mockResponse);
+
+      expect(result).toBeUndefined();
+      expect(mockResponse.status).toHaveBeenCalledWith(204);
     });
     it('throws HttpEception when the account has no MsaId', async () => {
       const spy = jest.spyOn(blockchainRpcQueryService, 'publicKeyToMsaId').mockResolvedValueOnce(null);
-      await expect(icsController.publishAll({ accountId: goodAccountId }, mockIcsPublishAllPayload)).rejects.toThrow(
-        HttpException,
-      );
+      await expect(
+        icsController.publishAll({ accountId: goodAccountId }, mockIcsPublishAllPayload, mockResponse),
+      ).rejects.toThrow(HttpException);
       expect(spy).toHaveBeenCalledWith(goodAccountId);
     });
   });

--- a/apps/account-api/src/controllers/v1/ics.controller.v1.spec.ts
+++ b/apps/account-api/src/controllers/v1/ics.controller.v1.spec.ts
@@ -71,7 +71,7 @@ describe('IcsController', () => {
 
   describe('basic', () => {
     const goodAccountId = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
-    const mockIcsPublishAllPayload = createIcsPublishAllRequestDto('0x1234');
+    const mockIcsPublishAllPayload = createIcsPublishAllRequestDto('0x1234', 3);
     const mockResponse = {
       status: jest.fn(),
     } as any;

--- a/apps/account-api/src/controllers/v1/ics.controller.v1.ts
+++ b/apps/account-api/src/controllers/v1/ics.controller.v1.ts
@@ -7,13 +7,14 @@ import {
   UpsertPagePayloadDto,
 } from '#types/dtos/account';
 import { AccountIdDto } from '#types/dtos/common';
-import { Body, Controller, HttpCode, HttpException, HttpStatus, Param, Post } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Body, Controller, HttpCode, HttpException, HttpStatus, Param, Post, Res } from '@nestjs/common';
+import { ApiAcceptedResponse, ApiNoContentResponse, ApiTags } from '@nestjs/swagger';
 import { ApiPromise } from '@polkadot/api';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { ISubmittableResult } from '@polkadot/types/types';
 import { HexString } from '@polkadot/util/types';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { Response } from 'express';
 import { BlockchainRpcQueryService } from '#blockchain/blockchain-rpc-query.service';
 import { chainSignature } from '#utils/common/signature.util';
 import { TransactionType } from '#types/tx-notification-webhook';
@@ -29,10 +30,20 @@ export class IcsControllerV1 {
 
   @Post(':accountId/publishAll')
   @HttpCode(HttpStatus.ACCEPTED)
+  @ApiAcceptedResponse({
+    description: 'Publish-all request accepted and enqueued',
+    schema: {
+      type: 'object',
+      properties: { referenceId: { type: 'string' } },
+      required: ['referenceId'],
+    },
+  })
+  @ApiNoContentResponse({ description: 'No payloads were provided, so no work was enqueued' })
   async publishAll(
     @Param() { accountId }: AccountIdDto,
     @Body() payloads: IcsPublishAllRequestDto,
-  ): Promise<{ referenceId: string }> {
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<{ referenceId: string } | void> {
     // check that the accountId has an MSA on chain as a fast, early failure.
     // it's not necessary to deserialize the payload to verify the id matches.
     const hasMsa = (await this.blockchainService.publicKeyToMsaId(accountId)) !== null;
@@ -40,6 +51,10 @@ export class IcsControllerV1 {
       throw new HttpException(`Account has NO MSA on chain: ${accountId}`, HttpStatus.BAD_REQUEST);
     }
     const referenceId = await this.buildAndEnqueueIcsBatchTxns(accountId, payloads);
+    if (referenceId === null) {
+      res.status(HttpStatus.NO_CONTENT);
+      return;
+    }
     return { referenceId };
   }
 
@@ -73,14 +88,27 @@ export class IcsControllerV1 {
     return { pallet: 'statefulStorage', extrinsicName: 'upsertPageWithSignatureV2', encodedExtrinsic: tx.toHex() };
   }
 
-  async buildAndEnqueueIcsBatchTxns(accountId: string, payloads: IcsPublishAllRequestDto): Promise<string> {
+  async buildAndEnqueueIcsBatchTxns(accountId: string, payloads: IcsPublishAllRequestDto): Promise<string | null> {
     const api = (await this.blockchainService.getApi()) as ApiPromise;
     const txns: Array<EncodedExtrinsic> = [];
 
     // Build the three extrinsics
-    txns.push(this.buildApplyItemActionExtrinsic(accountId, payloads.addIcsPublicKeyPayload, api));
-    txns.push(this.buildApplyItemActionExtrinsic(accountId, payloads.addContextGroupPRIDEntryPayload, api));
-    txns.push(this.buildUpsertPageExtrinsic(accountId, payloads.addContentGroupMetadataPayload, api));
+    if (payloads.addIcsPublicKeyPayload) {
+      txns.push(this.buildApplyItemActionExtrinsic(accountId, payloads.addIcsPublicKeyPayload, api));
+    }
+
+    if (payloads.addContextGroupPRIDEntryPayload) {
+      txns.push(this.buildApplyItemActionExtrinsic(accountId, payloads.addContextGroupPRIDEntryPayload, api));
+    }
+
+    if (payloads.addContentGroupMetadataPayload) {
+      txns.push(this.buildUpsertPageExtrinsic(accountId, payloads.addContentGroupMetadataPayload, api));
+    }
+
+    if (txns.length === 0) {
+      this.logger.warn('Received `publishAll` request with no payloads for account %s', accountId);
+      return null;
+    }
 
     this.logger.debug(`Enqueueing ICS batch with ${txns.length} extrinsics`);
     const { referenceId } = await this.enqueueService.enqueueRequest<PublishCapacityBatchRequestDto>({

--- a/apps/account-api/test/ics.controller.e2e-spec.ts
+++ b/apps/account-api/test/ics.controller.e2e-spec.ts
@@ -2,7 +2,7 @@
 import apiConfig, { IAccountApiConfig } from '#account-api/api.config';
 import { ApiModule } from '#account-api/api.module';
 import { TimeoutInterceptor } from '#utils/interceptors/timeout.interceptor';
-import { ValidationPipe, VersioningType } from '@nestjs/common';
+import { HttpStatus, ValidationPipe, VersioningType } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -86,28 +86,24 @@ describe('Ics Controller', () => {
         let goodId = getUnifiedAddress(provider.keypair);
         const url = `/v1/ics/${goodId}/publishAll`;
         const resp = await request(app.getHttpServer()).post(url).send(goodIcsPublishAllPayload);
-        console.log(resp.body);
-        expect(resp.status).toBe(202); // TODO: was 400 in test
-        expect(resp.body?.referenceId).toBeDefined();
+        expect(resp.status).toBe(HttpStatus.ACCEPTED);
+        expect(resp.body).toEqual(expect.objectContaining({ referenceId: expect.any(String) }));
       }, 5_000);
 
       it('key with no msaid', async () => {
         const newKey = keyring.addFromSeed(Uint8Array.from(Array(32).fill(3)));
         const newAddr = getUnifiedAddress(newKey);
         const url = `/v1/ics/${newAddr}/publishAll`;
-        await request(app.getHttpServer()).post(url).send(goodIcsPublishAllPayload).expect(400);
+        await request(app.getHttpServer()).post(url).send(goodIcsPublishAllPayload).expect(HttpStatus.BAD_REQUEST);
       });
     });
     describe('payload verification', () => {
-      it('requires all payloads', async () => {
-        let badPayload = {
-          ...goodIcsPublishAllPayload,
-          addIcsPublicKeyPayload: undefined,
-        };
+      it('returns no content when no payloads are provided', async () => {
         let goodId = getUnifiedAddress(provider.keypair);
         const url = `/v1/ics/${goodId}/publishAll`;
-        const resp = await request(app.getHttpServer()).post(url).send(badPayload);
-        expect(resp.status).toBe(400);
+        const resp = await request(app.getHttpServer()).post(url).send({});
+        expect(resp.status).toBe(HttpStatus.NO_CONTENT);
+        expect(resp.body).toEqual({});
       });
     });
   });

--- a/apps/account-api/test/ics.controller.e2e-spec.ts
+++ b/apps/account-api/test/ics.controller.e2e-spec.ts
@@ -79,22 +79,34 @@ describe('Ics Controller', () => {
   });
 
   describe('(POST) v1/ics/:accountId/publishAll', () => {
-    const goodIcsPublishAllPayload = createIcsPublishAllRequestDto();
-
     describe('accountId parameter verification', () => {
-      it('happy path submits to worker, returning reference Id', async () => {
-        let goodId = getUnifiedAddress(provider.keypair);
-        const url = `/v1/ics/${goodId}/publishAll`;
-        const resp = await request(app.getHttpServer()).post(url).send(goodIcsPublishAllPayload);
-        expect(resp.status).toBe(HttpStatus.ACCEPTED);
-        expect(resp.body).toEqual(expect.objectContaining({ referenceId: expect.any(String) }));
-      }, 5_000);
+      let goodId: string;
+
+      beforeAll(() => {
+        goodId = getUnifiedAddress(provider.keypair);
+      });
+
+      it.each([1, 2, 3])(
+        'happy path with %d payloads submits to worker, returning reference Id',
+        async (numPayloads) => {
+          const url = `/v1/ics/${goodId}/publishAll`;
+          const resp = await request(app.getHttpServer())
+            .post(url)
+            .send(createIcsPublishAllRequestDto(null, numPayloads));
+          expect(resp.status).toBe(HttpStatus.ACCEPTED);
+          expect(resp.body).toEqual(expect.objectContaining({ referenceId: expect.any(String) }));
+        },
+        5_000,
+      );
 
       it('key with no msaid', async () => {
         const newKey = keyring.addFromSeed(Uint8Array.from(Array(32).fill(3)));
         const newAddr = getUnifiedAddress(newKey);
         const url = `/v1/ics/${newAddr}/publishAll`;
-        await request(app.getHttpServer()).post(url).send(goodIcsPublishAllPayload).expect(HttpStatus.BAD_REQUEST);
+        await request(app.getHttpServer())
+          .post(url)
+          .send(createIcsPublishAllRequestDto())
+          .expect(HttpStatus.BAD_REQUEST);
       });
     });
     describe('payload verification', () => {

--- a/libs/types/src/dtos/account/ics-request-dto.spec.ts
+++ b/libs/types/src/dtos/account/ics-request-dto.spec.ts
@@ -1,11 +1,7 @@
 import { validate, ValidationError } from 'class-validator';
 import { AddNewPublicKeyAgreementRequestDto } from '#types/dtos/account/graphs.request.dto';
 import { IcsPublishAllRequestDto, UpsertPagePayloadDto } from '#types/dtos/account/ics.request.dto';
-import {
-  createIcsPublishAllRequestDto,
-  createItemizedSignaturePayloadDto,
-  createUpsertPagePayloadDto,
-} from '#testlib/payloadDtos.spec';
+import { createIcsPublishAllRequestDto, createItemizedSignaturePayloadDto } from '#testlib/payloadDtos.spec';
 
 function flattenErrors(errors: ValidationError[]) {
   return errors

--- a/libs/types/src/dtos/account/ics-request-dto.spec.ts
+++ b/libs/types/src/dtos/account/ics-request-dto.spec.ts
@@ -1,6 +1,6 @@
 import { validate, ValidationError } from 'class-validator';
 import { AddNewPublicKeyAgreementRequestDto } from '#types/dtos/account/graphs.request.dto';
-import { IcsPublishAllRequestDto } from '#types/dtos/account/ics.request.dto';
+import { IcsPublishAllRequestDto, UpsertPagePayloadDto } from '#types/dtos/account/ics.request.dto';
 import {
   createIcsPublishAllRequestDto,
   createItemizedSignaturePayloadDto,
@@ -34,19 +34,16 @@ async function validateDto(dto: any) {
 }
 
 describe('IcsPublishAllRequestDto', () => {
-  it('requires all payloads to be present', async () => {
-    const dto = new IcsPublishAllRequestDto();
+  it.each([0, 1, 2, 3])('Object with %d payload(s) is valid', async (numPayloads) => {
+    const dto = createIcsPublishAllRequestDto(null, numPayloads);
     const errors = await validateDto(dto);
-    expect(errors).toEqual([
-      'addIcsPublicKeyPayload should not be empty',
-      'addContextGroupPRIDEntryPayload should not be empty',
-      'addContentGroupMetadataPayload should not be empty',
-    ]);
+    expect(errors).toEqual([]);
   });
+
   it('requires payloads to be valid', async () => {
     let dto = new IcsPublishAllRequestDto();
     dto.addIcsPublicKeyPayload = new AddNewPublicKeyAgreementRequestDto();
-    const errors = await validateDto(dto);
+    let errors = await validateDto(dto);
     expect(errors).toContain(
       'accountId should be a valid 32 bytes representing an account Id or address in Hex or SS58 format!',
     );
@@ -56,12 +53,17 @@ describe('IcsPublishAllRequestDto', () => {
     );
 
     dto.addIcsPublicKeyPayload = undefined;
-    dto.addContentGroupMetadataPayload = createUpsertPagePayloadDto('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY');
-    expect(errors).toContain('payload should not be empty');
+    dto.addContentGroupMetadataPayload = new UpsertPagePayloadDto();
+    errors = await validateDto(dto);
     expect(errors).toContain(
-      'proof should be a valid 64 bytes Sr25519 signature value in hex! Or a valid 65-66 bytes MultiSignature value in hex!',
+      'accountId should be a valid 32 bytes representing an account Id or address in Hex or SS58 format!',
     );
+    expect(errors).toContain(
+      'signature should be a valid 64 bytes Sr25519 signature value in hex! Or a valid 65-66 bytes MultiSignature value in hex!',
+    );
+    expect(errors).toContain('payload should not be empty');
   });
+
   it('correctly validates a good payload', async () => {
     const goodActionitemPayload = createItemizedSignaturePayloadDto('0x9999');
     await expect(validateDto(goodActionitemPayload)).resolves.toHaveLength(0);

--- a/libs/types/src/dtos/account/ics.request.dto.ts
+++ b/libs/types/src/dtos/account/ics.request.dto.ts
@@ -1,7 +1,7 @@
 import { AddNewPublicKeyAgreementRequestDto } from '#types/dtos/account/graphs.request.dto';
 import { IsSchemaId } from '#utils/decorators/is-schema-id.decorator';
 import { HexString } from '@polkadot/util/types';
-import { IsNotEmpty, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { IsHexValue } from '#utils/decorators';
 import { IsSignature } from '#utils/decorators/is-signature.decorator';
@@ -72,17 +72,17 @@ export class UpsertPagePayloadDto {
 
 export class IcsPublishAllRequestDto {
   @ValidateNested()
-  @IsNotEmpty()
+  @IsOptional()
   @Type(() => AddNewPublicKeyAgreementRequestDto)
   addIcsPublicKeyPayload: AddNewPublicKeyAgreementRequestDto;
 
   @ValidateNested()
-  @IsNotEmpty()
+  @IsOptional()
   @Type(() => AddNewPublicKeyAgreementRequestDto)
   addContextGroupPRIDEntryPayload: AddNewPublicKeyAgreementRequestDto;
 
   @ValidateNested()
-  @IsNotEmpty()
+  @IsOptional()
   @Type(() => UpsertPagePayloadDto)
   addContentGroupMetadataPayload: UpsertPagePayloadDto;
 }

--- a/libs/types/src/dtos/account/ics.request.dto.ts
+++ b/libs/types/src/dtos/account/ics.request.dto.ts
@@ -74,17 +74,17 @@ export class IcsPublishAllRequestDto {
   @ValidateNested()
   @IsOptional()
   @Type(() => AddNewPublicKeyAgreementRequestDto)
-  addIcsPublicKeyPayload: AddNewPublicKeyAgreementRequestDto;
+  addIcsPublicKeyPayload?: AddNewPublicKeyAgreementRequestDto;
 
   @ValidateNested()
   @IsOptional()
   @Type(() => AddNewPublicKeyAgreementRequestDto)
-  addContextGroupPRIDEntryPayload: AddNewPublicKeyAgreementRequestDto;
+  addContextGroupPRIDEntryPayload?: AddNewPublicKeyAgreementRequestDto;
 
   @ValidateNested()
   @IsOptional()
   @Type(() => UpsertPagePayloadDto)
-  addContentGroupMetadataPayload: UpsertPagePayloadDto;
+  addContentGroupMetadataPayload?: UpsertPagePayloadDto;
 }
 
 export type PublishIcsPublishAllRequestDto = IcsPublishAllRequestDto & { type: TransactionType.CAPACITY_BATCH };

--- a/openapi-specs/account.openapi.json
+++ b/openapi-specs/account.openapi.json
@@ -691,7 +691,25 @@
         },
         "responses": {
           "202": {
-            "description": ""
+            "description": "Publish-all request accepted and enqueued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "referenceId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "referenceId"
+                  ]
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No payloads were provided, so no work was enqueued"
           }
         },
         "tags": [

--- a/openapi-specs/account.openapi.json
+++ b/openapi-specs/account.openapi.json
@@ -1552,12 +1552,7 @@
           "addContentGroupMetadataPayload": {
             "$ref": "#/components/schemas/UpsertPagePayloadDto"
           }
-        },
-        "required": [
-          "addIcsPublicKeyPayload",
-          "addContextGroupPRIDEntryPayload",
-          "addContentGroupMetadataPayload"
-        ]
+        }
       }
     }
   },

--- a/testlib/payloadDtos.spec.ts
+++ b/testlib/payloadDtos.spec.ts
@@ -67,10 +67,16 @@ export function createUpsertPagePayloadDto(accountId: string): UpsertPagePayload
   return dto;
 }
 
-export function createIcsPublishAllRequestDto(accountId?: string): IcsPublishAllRequestDto {
+export function createIcsPublishAllRequestDto(accountId?: string, numPayloads?: number): IcsPublishAllRequestDto {
   const dto = new IcsPublishAllRequestDto();
-  dto.addIcsPublicKeyPayload = createAddNewPublicKeyAgreementRequestDto(accountId || goodAccountId);
-  dto.addContextGroupPRIDEntryPayload = createAddNewPublicKeyAgreementRequestDto(accountId || goodAccountId);
-  dto.addContentGroupMetadataPayload = createUpsertPagePayloadDto(accountId || goodAccountId);
+  if (numPayloads >= 1) {
+    dto.addIcsPublicKeyPayload = createAddNewPublicKeyAgreementRequestDto(accountId || goodAccountId);
+  }
+  if (numPayloads >= 2) {
+    dto.addContextGroupPRIDEntryPayload = createAddNewPublicKeyAgreementRequestDto(accountId || goodAccountId);
+  }
+  if (numPayloads >= 3) {
+    dto.addContentGroupMetadataPayload = createUpsertPagePayloadDto(accountId || goodAccountId);
+  }
   return dto;
 }


### PR DESCRIPTION
# Purpose

The goal of this PR is be able to handle 0, 1, 2, or 3 payloads in the `POST v1/accounts/:accountId/publishAll` endpoint.

References FR-133

## Background
Upstream, Frequency Access may return 1, 2, or 3 signed payloads to submit to the chain, based on what's already detected on-chain. ICS MCP server will pass whatever payloads it gets back from FA on to Gateway to submit to the chain.

### Change summary
- Make the three payloads in `IcsPublishAllRequestDto` optional
- Have the endpoint logic only add payloads that exist to the batch transaction submitted to the chain
- If no payloads are in the request, return `HTTP 204 NOT FOUND`
- Updated OpenAPI docs

### Checklist

Delete items that don't apply or mark Not Applicable

- [x] Unit tests added/updated
- [x] Documentation added or updated (where applicable)
- [x] API endpoints added or changed? Added the endpoints in main.ts and regenerate Swagger docs
- ~[ ] New packages are noted in the description or summary with what they do~
- ~[ ] Breaking changes? "breaking changes" label added.~
- ~Environment variable changes? This is a breaking change for deployment:~
    - ~[ ] Update docker files,  files, environment templates~
    - ~[ ] Update config Joi validations, and config setup in tests~
    - ~[ ] Make a pull request for any *-infra repositories with a deployed Gateway instance. Merge this _first_ 
before merging this PR.~
