### PR TITLE
add watched tx failure notifications

### DIFF
--- a/apps/account-worker/src/transaction_notifier/notifier.service.spec.ts
+++ b/apps/account-worker/src/transaction_notifier/notifier.service.spec.ts
@@ -6,7 +6,7 @@ import Redis from 'ioredis';
 import { CapacityCheckerService } from '#blockchain/capacity-checker.service';
 import accountWorkerConfig from '#account-worker/worker.config';
 import { TxnNotifierService } from './notifier.service';
-import { TransactionType } from '#types/tx-notification-webhook';
+import { TransactionStatus, TransactionType } from '#types/tx-notification-webhook';
 import { TXN_WATCH_LIST_KEY } from '#types/constants';
 import { mockCacheManagerWith, mockRedisProvider } from '#testlib';
 import { jest } from '@jest/globals';
@@ -160,7 +160,9 @@ describe('TxnNotifierService', () => {
         },
       };
       await service.processCurrentBlock(mockBlock, [mockFailureEvent as any]);
-      expect(providerWebhookService.notify).not.toHaveBeenCalled();
+      expect(providerWebhookService.notify).toHaveBeenCalledWith(
+        expect.objectContaining({ status: TransactionStatus.FAILED }),
+      );
       expect(cacheManager.multi().hdel).toHaveBeenCalledWith(TXN_WATCH_LIST_KEY, txHash);
     });
 

--- a/apps/account-worker/src/transaction_notifier/notifier.service.ts
+++ b/apps/account-worker/src/transaction_notifier/notifier.service.ts
@@ -5,7 +5,14 @@ import { createWebhookRsp } from '#webhooks-lib/helpers/createWebhookRsp.helper'
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { IBaseTxStatus } from '#types/interfaces';
 import { CapacityCheckerService } from '#blockchain/capacity-checker.service';
-import { CapacityBatchAllOpts, TransactionType, TxWebhookRsp } from '#types/tx-notification-webhook';
+import {
+  CapacityBatchAllOpts,
+  TransactionStatus,
+  TransactionType,
+  TxWebhookExpiredRsp,
+  TxWebhookFailureRsp,
+  TxWebhookRsp,
+} from '#types/tx-notification-webhook';
 import accountWorkerConfig, { IAccountWorkerConfig } from '#account-worker/worker.config';
 import { PinoLogger } from 'nestjs-pino';
 import { BlockchainRpcQueryService } from '#blockchain/blockchain-rpc-query.service';
@@ -15,6 +22,8 @@ import {
   WatchedTransactionScannerService,
 } from '#blockchain/watched-transaction-scanner.service';
 import { BaseWebhookService } from '#webhooks-lib/base.webhook.service';
+import { base2 } from 'multiformats/bases/base2';
+import { SignedBlock } from '@polkadot/types/interfaces';
 
 // For watching transactions directly on chain.
 @Injectable()
@@ -32,9 +41,26 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
   }
 
   public async handleTransactionFailure({
+    txStatus,
+    currentBlock,
     moduleError,
   }: IWatchedTransactionFailureContext<IBaseTxStatus>): Promise<void> {
     this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
+    const { type: transactionType, providerId, referenceId, txHash } = txStatus;
+    const baseResponse = {
+      type: transactionType,
+      providerId,
+      referenceId,
+      txHash,
+      blockHash: currentBlock.block.header.hash.toHex(),
+    };
+
+    const response: TxWebhookFailureRsp = {
+      ...baseResponse,
+      status: TransactionStatus.FAILED,
+      error: JSON.stringify(moduleError),
+    };
+    await this.sendWebhookNotification(response);
   }
 
   public async handleTransactionSuccess({
@@ -165,13 +191,17 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
       return;
     }
 
+    await this.sendWebhookNotification(webhookResponse);
+  }
+
+  private async sendWebhookNotification(webhookResponse: TxWebhookRsp): Promise<void> {
     let retries = 0;
     while (retries < this.workerConfig.healthCheckMaxRetries) {
       try {
         this.logger.debug(webhookResponse, 'Sending transaction notification to webhook');
         await this.providerWebhookService.notify(webhookResponse);
         this.logger.debug('Transaction Notification sent to webhook');
-        break;
+        return;
       } catch (error) {
         this.logger.error(error, 'Failed to send notification to webhook');
         retries += 1;
@@ -179,9 +209,23 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     }
   }
 
-  public async handleTransactionExpired(txStatus: IBaseTxStatus, currentBlockNumber: number): Promise<void> {
+  public async handleTransactionExpired(txStatus: IBaseTxStatus, currentBlock: SignedBlock): Promise<void> {
     this.logger.trace(
-      `Tx ${txStatus.txHash} expired (birth: ${txStatus.birth}, death: ${txStatus.death}, currentBlock: ${currentBlockNumber})`,
+      `Tx ${txStatus.txHash} expired (birth: ${txStatus.birth}, death: ${txStatus.death}, currentBlock: ${currentBlock.block.header.number.toNumber()})`,
     );
+    const { type: transactionType, providerId, referenceId, txHash } = txStatus;
+    const baseResponse = {
+      type: transactionType,
+      providerId,
+      referenceId,
+      txHash,
+      blockHash: currentBlock.block.header.hash.toHex(),
+    };
+
+    const response: TxWebhookExpiredRsp = {
+      ...baseResponse,
+      status: TransactionStatus.EXPIRED,
+    };
+    await this.sendWebhookNotification(response);
   }
 }

--- a/apps/account-worker/src/transaction_notifier/notifier.service.ts
+++ b/apps/account-worker/src/transaction_notifier/notifier.service.ts
@@ -22,7 +22,6 @@ import {
   WatchedTransactionScannerService,
 } from '#blockchain/watched-transaction-scanner.service';
 import { BaseWebhookService } from '#webhooks-lib/base.webhook.service';
-import { base2 } from 'multiformats/bases/base2';
 import { SignedBlock } from '@polkadot/types/interfaces';
 
 // For watching transactions directly on chain.

--- a/apps/account-worker/src/transaction_notifier/notifier.service.ts
+++ b/apps/account-worker/src/transaction_notifier/notifier.service.ts
@@ -48,7 +48,7 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
     const { type: transactionType, providerId, referenceId, txHash } = txStatus;
     const baseResponse = {
-      type: transactionType,
+      transactionType,
       providerId,
       referenceId,
       txHash,
@@ -72,7 +72,11 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     successEvent,
   }: IWatchedTransactionSuccessContext<IBaseTxStatus>): Promise<void> {
     this.logger.trace(`Successfully found transaction ${txStatus.txHash} in block ${currentBlockNumber}`);
-    const baseResponse = { ...txStatus, blockHash: currentBlock.block.header.hash.toHex() };
+    const baseResponse = {
+      ...txStatus,
+      blockHash: currentBlock.block.header.hash.toHex(),
+      status: TransactionStatus.SUCCESS,
+    };
     let webhookResponse: TxWebhookRsp | undefined;
 
     switch (txStatus.type) {
@@ -215,7 +219,7 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     );
     const { type: transactionType, providerId, referenceId, txHash } = txStatus;
     const baseResponse = {
-      type: transactionType,
+      transactionType,
       providerId,
       referenceId,
       txHash,

--- a/apps/account-worker/test/app.e2e-spec.ts
+++ b/apps/account-worker/test/app.e2e-spec.ts
@@ -12,6 +12,7 @@ import { AccountQueues } from '#types/constants/queue.constants';
 import {
   type getHealthzData,
   type postWebhooksTransactionNotifyData,
+  TransactionStatus,
   TransactionType,
   TxWebhookRsp,
 } from '#types/tx-notification-webhook';
@@ -362,6 +363,7 @@ describe('Account Service E2E request verification!', () => {
       },
       providerId,
       referenceId,
+      status: TransactionStatus.SUCCESS,
       transactionType: TransactionType.CAPACITY_BATCH,
       txHash: expect.stringMatching(/0x[a-fA-F0-9]{32}/),
     });

--- a/apps/account-worker/test/app.e2e-spec.ts
+++ b/apps/account-worker/test/app.e2e-spec.ts
@@ -25,10 +25,29 @@ import { createServer, IncomingHttpHeaders, IncomingMessage, Server, ServerRespo
 import { AddressInfo } from 'net';
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import path from 'path';
+import Redis from 'ioredis';
+import { DEFAULT_REDIS_NAMESPACE, getRedisToken } from '@songkeys/nestjs-redis';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { ApiPromise } from '@polkadot/api';
 
-process.env.CACHE_KEY_PREFIX = 'account-worker-e2e:';
+const CACHE_KEY_PREFIX = 'account-worker-e2e:';
+process.env.CACHE_KEY_PREFIX = CACHE_KEY_PREFIX;
 jest.setTimeout(120_000);
 
+async function clearAllRedisKeys(redis: Redis) {
+  const keys = await redis.keys(`${CACHE_KEY_PREFIX}*`);
+  let pipeline = redis.pipeline();
+  keys.forEach((k) => {
+    pipeline = pipeline.del(k.replace(CACHE_KEY_PREFIX, ''));
+  });
+  await pipeline.exec();
+}
+
+async function runBlocks(api: ApiPromise, count: number = 64) {
+  for (let i = 0; i <= count; i++) {
+    await api.rpc.engine.createBlock(true, true);
+  }
+}
 describe('Account Service E2E request verification!', () => {
   const WEBHOOK_TRANSACTION_NOTIFY_PATH: postWebhooksTransactionNotifyData['url'] = '/webhooks/transaction-notify';
   const HEALTHZ_PATH: getHealthzData['url'] = '/healthz';
@@ -44,6 +63,7 @@ describe('Account Service E2E request verification!', () => {
   let blockchainService: BlockchainService;
   let prismProcess: ChildProcessWithoutNullStreams | undefined;
   let captureServer: Server | undefined;
+  let redisConnection: Redis;
   const receivedWebhooks: { body: TxWebhookRsp; headers: IncomingHttpHeaders }[] = [];
 
   const getFreePort = async (): Promise<number> =>
@@ -198,6 +218,7 @@ describe('Account Service E2E request verification!', () => {
     await txQueueEvents.waitUntilReady();
     txNotifier = app.get<TxnNotifierService>(TxnNotifierService);
     blockchainService = app.get<BlockchainService>(BlockchainService);
+    redisConnection = app.get<Redis>(getRedisToken(DEFAULT_REDIS_NAMESPACE));
     const chainConfig = app.get<IBlockchainConfig>(blockchainConfig.KEY);
     providerId = chainConfig.providerId.toString();
 
@@ -214,6 +235,9 @@ describe('Account Service E2E request verification!', () => {
     if (txQueueEvents) {
       await txQueueEvents.close();
     }
+    if (redisConnection) {
+      await clearAllRedisKeys(redisConnection);
+    }
     if (app) {
       await app.close();
     }
@@ -227,147 +251,178 @@ describe('Account Service E2E request verification!', () => {
     });
   });
 
-  it(`(GET) ${HEALTHZ_PATH}`, () =>
-    request(httpServer)
-      .get(HEALTHZ_PATH)
-      .expect(200)
-      .then((res) => {
-        const baseConfigExpectation: { [key: string]: any } = {
-          apiBodyJsonLimit: expect.any(String),
-          apiPort: expect.any(Number),
-          apiTimeoutMs: expect.any(Number),
-          blockchainScanIntervalSeconds: expect.any(Number),
-          healthCheckMaxRetries: expect.any(Number),
-          healthCheckMaxRetryIntervalSeconds: expect.any(Number),
-          healthCheckSuccessThreshold: expect.any(Number),
-          providerApiToken: expect.any(String),
-          trustUnfinalizedBlocks: expect.any(Boolean),
-          webhookBaseUrl: expect.any(String),
-          webhookFailureThreshold: expect.any(Number),
-          webhookRetryIntervalSeconds: expect.any(Number),
-        };
+  describe('health and metrics endpoints', () => {
+    it(`(GET) ${HEALTHZ_PATH}`, () =>
+      request(httpServer)
+        .get(HEALTHZ_PATH)
+        .expect(200)
+        .then((res) => {
+          const baseConfigExpectation: { [key: string]: any } = {
+            apiBodyJsonLimit: expect.any(String),
+            apiPort: expect.any(Number),
+            apiTimeoutMs: expect.any(Number),
+            blockchainScanIntervalSeconds: expect.any(Number),
+            healthCheckMaxRetries: expect.any(Number),
+            healthCheckMaxRetryIntervalSeconds: expect.any(Number),
+            healthCheckSuccessThreshold: expect.any(Number),
+            providerApiToken: expect.any(String),
+            trustUnfinalizedBlocks: expect.any(Boolean),
+            webhookBaseUrl: expect.any(String),
+            webhookFailureThreshold: expect.any(Number),
+            webhookRetryIntervalSeconds: expect.any(Number),
+          };
 
-        expect(res.body).toEqual(
-          expect.objectContaining({
-            status: 200,
-            message: 'Service is healthy',
-            timestamp: expect.any(Number),
-            config: expect.objectContaining(baseConfigExpectation),
-            redisStatus: expect.objectContaining({
-              connected_clients: expect.any(Number),
-              maxmemory: expect.any(Number),
-              redis_version: expect.any(String),
-              uptime_in_seconds: expect.any(Number),
-              used_memory: expect.any(Number),
-              queues: expect.arrayContaining([
-                expect.objectContaining({
-                  name: expect.any(String),
-                  waiting: expect.any(Number),
-                  active: expect.any(Number),
-                  completed: expect.any(Number),
-                  failed: expect.any(Number),
-                  delayed: expect.any(Number),
+          expect(res.body).toEqual(
+            expect.objectContaining({
+              status: 200,
+              message: 'Service is healthy',
+              timestamp: expect.any(Number),
+              config: expect.objectContaining(baseConfigExpectation),
+              redisStatus: expect.objectContaining({
+                connected_clients: expect.any(Number),
+                maxmemory: expect.any(Number),
+                redis_version: expect.any(String),
+                uptime_in_seconds: expect.any(Number),
+                used_memory: expect.any(Number),
+                queues: expect.arrayContaining([
+                  expect.objectContaining({
+                    name: expect.any(String),
+                    waiting: expect.any(Number),
+                    active: expect.any(Number),
+                    completed: expect.any(Number),
+                    failed: expect.any(Number),
+                    delayed: expect.any(Number),
+                  }),
+                ]),
+              }),
+              blockchainStatus: expect.objectContaining({
+                frequencyApiWsUrl: expect.any(String),
+                latestBlockHeader: expect.objectContaining({
+                  blockHash: expect.any(String),
+                  number: expect.any(Number),
+                  parentHash: expect.any(String),
                 }),
-              ]),
-            }),
-            blockchainStatus: expect.objectContaining({
-              frequencyApiWsUrl: expect.any(String),
-              latestBlockHeader: expect.objectContaining({
-                blockHash: expect.any(String),
-                number: expect.any(Number),
-                parentHash: expect.any(String),
               }),
             }),
-          }),
-        );
-      }));
+          );
+        }));
 
-  it('(GET) /livez', () =>
-    request(httpServer).get('/livez').expect(200).expect({ status: 200, message: 'Service is live' }));
+    it('(GET) /livez', () =>
+      request(httpServer).get('/livez').expect(200).expect({ status: 200, message: 'Service is live' }));
 
-  it('(GET) /readyz', () =>
-    request(httpServer).get('/readyz').expect(200).expect({ status: 200, message: 'Service is ready' }));
+    it('(GET) /readyz', () =>
+      request(httpServer).get('/readyz').expect(200).expect({ status: 200, message: 'Service is ready' }));
 
-  it('(GET) /metrics', () => request(httpServer).get('/metrics').expect(200));
+    it('(GET) /metrics', () => request(httpServer).get('/metrics').expect(200));
+  });
 
-  it('submits CAPACITY_BATCH and posts expected webhook payload', async () => {
-    const referenceId = `capacity-batch-${Date.now()}`;
-    const api = (await blockchainService.getApi()) as any;
-    const delegatorKeypair = new Keyring({ type: 'sr25519' }).addFromUri(`//${referenceId}`);
-    const currentBlock = (await blockchainService.getBlockForSigning()).number;
-    const addProviderPayload = api.registry.createType('PalletMsaAddProvider', {
-      authorizedMsaId: providerId,
-      intentIds: [],
-      expiration: currentBlock + 10,
+  describe('Transaction submission and webhook notification', () => {
+    let delegatorKeypair: KeyringPair;
+
+    beforeAll(() => {
+      delegatorKeypair = new Keyring({ type: 'sr25519' }).addFromUri(`//${Date.now()}`);
     });
-    const encodedCall = api.tx.msa
-      .createSponsoredAccountWithDelegation(
-        delegatorKeypair.address,
-        signPayloadSr25519(delegatorKeypair, addProviderPayload),
-        addProviderPayload,
-      )
-      .toHex();
 
-    const job = await txQueue.add(
-      referenceId,
-      {
-        type: TransactionType.CAPACITY_BATCH,
-        providerId,
-        referenceId,
-        calls: [
-          {
-            pallet: 'system',
-            extrinsicName: 'remarkWithEvent',
-            encodedExtrinsic: encodedCall,
-          },
-        ],
-      } as any,
-      { jobId: referenceId },
-    );
+    beforeEach(async () => {
+      await clearAllRedisKeys(redisConnection);
+      while (receivedWebhooks.pop()) {}
+    });
 
-    await job.waitUntilFinished(txQueueEvents);
-
-    const webhookPayload = await (async () => {
-      const timeoutMs = 20_000;
-      const pollMs = 1_000;
-      const end = Date.now() + timeoutMs;
-
-      while (Date.now() < end) {
-        await (txNotifier as unknown as any).setLastSeenBlockNumber(currentBlock);
-        await txNotifier.scan();
-        const matchedCall = receivedWebhooks.find(
-          ({ body }) => (body as TxWebhookRsp | undefined)?.transactionType === TransactionType.CAPACITY_BATCH,
-        );
-        if (matchedCall) {
-          return matchedCall;
-        }
-        await new Promise<void>((resolve) => {
-          setTimeout(() => resolve(), pollMs);
+    it.each([TransactionStatus.SUCCESS, TransactionStatus.FAILED, TransactionStatus.EXPIRED])(
+      'submits CAPACITY_BATCH and posts expected webhook payload with %s status',
+      async (status) => {
+        const referenceId = `capacity-batch-${Date.now()}`;
+        const api = (await blockchainService.getApi()) as any;
+        const currentBlock = (await blockchainService.getBlockForSigning()).number;
+        const addProviderPayload = api.registry.createType('PalletMsaAddProvider', {
+          authorizedMsaId: providerId,
+          intentIds: [],
+          expiration: currentBlock + 10,
         });
-      }
+        const encodedCall = api.tx.msa
+          .createSponsoredAccountWithDelegation(
+            delegatorKeypair.address,
+            signPayloadSr25519(delegatorKeypair, addProviderPayload),
+            addProviderPayload,
+          )
+          .toHex();
 
-      throw new Error('Timed out waiting for CAPACITY_BATCH webhook');
-    })();
+        // Skip a nonce so that this transaction will stay in the queue until mortality
+        if (status === TransactionStatus.EXPIRED) {
+          await blockchainService.reserveNextNonce();
+        }
 
-    expect(webhookPayload.body).toEqual({
-      blockHash: expect.stringMatching(/0x[a-fA-F0-9]{32}/),
-      calls: [
-        {
-          section: 'msa',
-          method: 'createSponsoredAccountWithDelegation',
-        },
-      ],
-      capacityWithdrawnEvent: {
-        amount: expect.stringMatching(/^[0-9]+$/),
-        msaId: providerId,
+        const job = await txQueue.add(
+          referenceId,
+          {
+            type: TransactionType.CAPACITY_BATCH,
+            providerId,
+            referenceId,
+            calls: [
+              {
+                pallet: 'msa',
+                extrinsicName: 'createSponsoredAccountWithDelegation',
+                encodedExtrinsic: encodedCall,
+              },
+            ],
+          } as any,
+          { jobId: referenceId },
+        );
+
+        await job.waitUntilFinished(txQueueEvents);
+        await runBlocks(api);
+
+        const webhookPayload = await (async () => {
+          const timeoutMs = 20_000;
+          const pollMs = 1_000;
+          const end = Date.now() + timeoutMs;
+
+          while (Date.now() < end) {
+            await (txNotifier as unknown as any).setLastSeenBlockNumber(currentBlock);
+            await txNotifier.scan();
+            const matchedCall = receivedWebhooks.find(
+              ({ body }) => (body as TxWebhookRsp | undefined)?.transactionType === TransactionType.CAPACITY_BATCH,
+            );
+            if (matchedCall) {
+              return matchedCall;
+            }
+            await new Promise<void>((resolve) => {
+              setTimeout(() => resolve(), pollMs);
+            });
+          }
+
+          throw new Error('Timed out waiting for CAPACITY_BATCH webhook');
+        })();
+
+        expect(webhookPayload.body).toEqual({
+          blockHash: expect.stringMatching(/0x[a-fA-F0-9]{32}/),
+          calls:
+            status !== TransactionStatus.SUCCESS
+              ? undefined
+              : [
+                  {
+                    section: 'msa',
+                    method: 'createSponsoredAccountWithDelegation',
+                  },
+                ],
+          capacityWithdrawnEvent:
+            status !== TransactionStatus.SUCCESS
+              ? undefined
+              : {
+                  amount: expect.stringMatching(/^[0-9]+$/),
+                  msaId: providerId,
+                },
+          providerId,
+          referenceId,
+          error: status === TransactionStatus.FAILED ? expect.any(String) : undefined,
+          status,
+          transactionType: TransactionType.CAPACITY_BATCH,
+          txHash: expect.stringMatching(/0x[a-fA-F0-9]{32}/),
+        });
+        expect(webhookPayload.headers.authorization).toBe(providerApiToken);
+        expect(receivedWebhooks.length).toBeGreaterThan(0);
       },
-      providerId,
-      referenceId,
-      status: TransactionStatus.SUCCESS,
-      transactionType: TransactionType.CAPACITY_BATCH,
-      txHash: expect.stringMatching(/0x[a-fA-F0-9]{32}/),
-    });
-    expect(webhookPayload.headers.authorization).toBe(providerApiToken);
-    expect(receivedWebhooks.length).toBeGreaterThan(0);
-  }, 30_000);
+      30_000,
+    );
+  });
 });

--- a/apps/content-publishing-worker/src/monitor/tx.status.monitor.service.ts
+++ b/apps/content-publishing-worker/src/monitor/tx.status.monitor.service.ts
@@ -18,6 +18,7 @@ import {
   IWatchedTransactionSuccessContext,
   WatchedTransactionScannerService,
 } from '#blockchain/watched-transaction-scanner.service';
+import { SignedBlock } from '@polkadot/types/interfaces';
 
 @Injectable()
 export class TxStatusMonitoringService extends WatchedTransactionScannerService<IContentTxStatus> {
@@ -97,9 +98,9 @@ export class TxStatusMonitoringService extends WatchedTransactionScannerService<
     );
   }
 
-  public async handleTransactionExpired(txStatus: IContentTxStatus, currentBlockNumber: number): Promise<void> {
+  public async handleTransactionExpired(txStatus: IContentTxStatus, currentBlock: SignedBlock): Promise<void> {
     this.logger.warn(
-      `Tx ${txStatus.txHash} expired (birth: ${txStatus.birth}, death: ${txStatus.death}, currentBlock: ${currentBlockNumber}), adding back to the publishing queue`,
+      `Tx ${txStatus.txHash} expired (birth: ${txStatus.birth}, death: ${txStatus.death}, currentBlock: ${currentBlock.block.header.number.toNumber()}), adding back to the publishing queue`,
     );
     await this.retryPublishJob(txStatus.referencePublishJob);
   }

--- a/apps/content-publishing-worker/src/notifier/src/notifier.service.spec.ts
+++ b/apps/content-publishing-worker/src/notifier/src/notifier.service.spec.ts
@@ -6,7 +6,7 @@ import Redis from 'ioredis';
 import { CapacityCheckerService } from '#blockchain/capacity-checker.service';
 import workerConfig from '#content-publishing-worker/worker.config';
 import { TxnNotifierService } from './notifier.service';
-import { TransactionType } from '#types/tx-notification-webhook';
+import { TransactionStatus, TransactionType } from '#types/tx-notification-webhook';
 import { TXN_WATCH_LIST_KEY } from '#types/constants';
 import { mockCacheManagerWith, mockRedisProvider } from '#testlib';
 import { jest } from '@jest/globals';
@@ -148,7 +148,9 @@ describe('TxnNotifierService', () => {
         },
       };
       await service.processCurrentBlock(mockBlock, [mockFailureEvent as any]);
-      expect(providerWebhookService.notify).not.toHaveBeenCalled();
+      expect(providerWebhookService.notify).toHaveBeenCalledWith(
+        expect.objectContaining({ status: TransactionStatus.FAILED }),
+      );
       expect(cacheManager.multi().hdel).toHaveBeenCalledWith(TXN_WATCH_LIST_KEY, txHash);
     });
 
@@ -167,6 +169,9 @@ describe('TxnNotifierService', () => {
       const mockBlock = createMockBlock([]); // No matching extrinsics
       await service.processCurrentBlock(mockBlock, []);
 
+      expect(providerWebhookService.notify).toHaveBeenCalledWith(
+        expect.objectContaining({ status: TransactionStatus.EXPIRED }),
+      );
       expect(cacheManager.multi().hdel).toHaveBeenCalledWith(TXN_WATCH_LIST_KEY, expiredHash);
     });
 

--- a/apps/content-publishing-worker/src/notifier/src/notifier.service.ts
+++ b/apps/content-publishing-worker/src/notifier/src/notifier.service.ts
@@ -48,7 +48,7 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
     const { type: transactionType, providerId, referenceId, txHash } = txStatus;
     const baseResponse = {
-      type: transactionType,
+      transactionType,
       providerId,
       referenceId,
       txHash,
@@ -71,7 +71,11 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     currentBlockNumber,
   }: IWatchedTransactionSuccessContext<IBaseTxStatus>): Promise<void> {
     this.logger.trace(`Successfully found transaction ${txStatus.txHash} in block ${currentBlockNumber}`);
-    const baseResponse = { ...txStatus, blockHash: currentBlock.block.header.hash.toHex() };
+    const baseResponse = {
+      ...txStatus,
+      blockHash: currentBlock.block.header.hash.toHex(),
+      status: TransactionStatus.SUCCESS,
+    };
     let webhookResponse: TxWebhookRsp | undefined;
 
     if (txStatus.type === TransactionType.CAPACITY_BATCH) {
@@ -122,7 +126,7 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     );
     const { type: transactionType, providerId, referenceId, txHash } = txStatus;
     const baseResponse = {
-      type: transactionType,
+      transactionType,
       providerId,
       referenceId,
       txHash,

--- a/apps/content-publishing-worker/src/notifier/src/notifier.service.ts
+++ b/apps/content-publishing-worker/src/notifier/src/notifier.service.ts
@@ -4,7 +4,14 @@ import Redis from 'ioredis';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { SignedBlock } from '@polkadot/types/interfaces';
 import { CapacityCheckerService } from '#blockchain/capacity-checker.service';
-import { CapacityBatchAllOpts, TransactionType, TxWebhookRsp } from '#types/tx-notification-webhook';
+import {
+  CapacityBatchAllOpts,
+  TransactionStatus,
+  TransactionType,
+  TxWebhookExpiredRsp,
+  TxWebhookFailureRsp,
+  TxWebhookRsp,
+} from '#types/tx-notification-webhook';
 import { PinoLogger } from 'nestjs-pino';
 import { BlockchainRpcQueryService } from '#blockchain/blockchain-rpc-query.service';
 import {
@@ -34,9 +41,26 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
   }
 
   public async handleTransactionFailure({
+    txStatus,
+    currentBlock,
     moduleError,
   }: IWatchedTransactionFailureContext<IBaseTxStatus>): Promise<void> {
     this.logger.error(`Extrinsic failed with error: ${JSON.stringify(moduleError)}`);
+    const { type: transactionType, providerId, referenceId, txHash } = txStatus;
+    const baseResponse = {
+      type: transactionType,
+      providerId,
+      referenceId,
+      txHash,
+      blockHash: currentBlock.block.header.hash.toHex(),
+    };
+
+    const response: TxWebhookFailureRsp = {
+      ...baseResponse,
+      status: TransactionStatus.FAILED,
+      error: JSON.stringify(moduleError),
+    };
+    await this.sendWebhookNotification(response);
   }
 
   public async handleTransactionSuccess({
@@ -45,7 +69,6 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     currentBlock,
     extrinsicEvents,
     currentBlockNumber,
-    successEvent,
   }: IWatchedTransactionSuccessContext<IBaseTxStatus>): Promise<void> {
     this.logger.trace(`Successfully found transaction ${txStatus.txHash} in block ${currentBlockNumber}`);
     const baseResponse = { ...txStatus, blockHash: currentBlock.block.header.hash.toHex() };
@@ -75,13 +98,17 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
       return;
     }
 
+    await this.sendWebhookNotification(webhookResponse);
+  }
+
+  private async sendWebhookNotification(webhookResponse: TxWebhookRsp): Promise<void> {
     let retries = 0;
     while (retries < this.workerConfig.healthCheckMaxRetries) {
       try {
         this.logger.debug(webhookResponse, 'Sending transaction notification to webhook');
         await this.providerWebhookService.notify(webhookResponse);
         this.logger.debug('Transaction Notification sent to webhook');
-        break;
+        return;
       } catch (error) {
         this.logger.error(error, 'Failed to send notification to webhook');
         retries += 1;
@@ -89,9 +116,23 @@ export class TxnNotifierService extends WatchedTransactionScannerService<IBaseTx
     }
   }
 
-  public async handleTransactionExpired(txStatus: IBaseTxStatus, currentBlockNumber: number): Promise<void> {
+  public async handleTransactionExpired(txStatus: IBaseTxStatus, currentBlock: SignedBlock): Promise<void> {
     this.logger.trace(
-      `Tx ${txStatus.txHash} expired (birth: ${txStatus.birth}, death: ${txStatus.death}, currentBlock: ${currentBlockNumber})`,
+      `Tx ${txStatus.txHash} expired (birth: ${txStatus.birth}, death: ${txStatus.death}, currentBlock: ${currentBlock.block.header.number.toNumber()})`,
     );
+    const { type: transactionType, providerId, referenceId, txHash } = txStatus;
+    const baseResponse = {
+      type: transactionType,
+      providerId,
+      referenceId,
+      txHash,
+      blockHash: currentBlock.block.header.hash.toHex(),
+    };
+
+    const response: TxWebhookExpiredRsp = {
+      ...baseResponse,
+      status: TransactionStatus.EXPIRED,
+    };
+    await this.sendWebhookNotification(response);
   }
 }

--- a/apps/content-publishing-worker/src/publisher/publishing.service.ts
+++ b/apps/content-publishing-worker/src/publisher/publishing.service.ts
@@ -67,7 +67,7 @@ export class PublishingService extends BaseConsumer implements OnApplicationBoot
       }
       this.logger.debug(`Processing job ${job.id} of type ${job.name}`);
 
-      let txType = TransactionType.CAPACITY_BATCH;
+      let txType: TransactionType = TransactionType.CAPACITY_BATCH;
 
       // Check for valid delegation if appropriate (chain would reject anyway, but this saves Capacity)
       if (isOnChainJob(jobData) && typeof jobData.data.onBehalfOf !== 'undefined') {

--- a/libs/blockchain/src/watched-transaction-scanner.service.spec.ts
+++ b/libs/blockchain/src/watched-transaction-scanner.service.spec.ts
@@ -280,7 +280,10 @@ describe('WatchedTransactionScannerService', () => {
 
         // The only pending txn left after processing extrinsics should be the expired one.
         expect(handleTransactionExpiredSpy).toHaveBeenCalledTimes(1);
-        expect(handleTransactionExpiredSpy).toHaveBeenCalledWith(expect.objectContaining({ txHash: expiredHash }), 100);
+        expect(handleTransactionExpiredSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ txHash: expiredHash }),
+          expect.objectContaining({ block: expect.any(Object) }),
+        );
 
         const deletedHashes = mockRedis.hdel.mock.calls
           .filter(([key]) => key === TXN_WATCH_LIST_KEY)

--- a/libs/blockchain/src/watched-transaction-scanner.service.ts
+++ b/libs/blockchain/src/watched-transaction-scanner.service.ts
@@ -178,7 +178,7 @@ export abstract class WatchedTransactionScannerService<TTxStatus extends IWatche
     // eslint-disable-next-line no-restricted-syntax
     for (const txStatus of pendingTxnsByHash.values()) {
       if (txStatus.death <= currentBlockNumber) {
-        await this.handleTransactionExpired(txStatus, currentBlockNumber);
+        await this.handleTransactionExpired(txStatus, currentBlock);
         pipeline = pipeline.hdel(TXN_WATCH_LIST_KEY, txStatus.txHash);
       }
     }
@@ -232,5 +232,5 @@ export abstract class WatchedTransactionScannerService<TTxStatus extends IWatche
 
   public abstract handleTransactionFailure(context: IWatchedTransactionFailureContext<TTxStatus>): Promise<void>;
 
-  public abstract handleTransactionExpired(txStatus: TTxStatus, currentBlockNumber: number): Promise<void>;
+  public abstract handleTransactionExpired(txStatus: TTxStatus, currentBlock: SignedBlock): Promise<void>;
 }

--- a/libs/types/src/dtos/account/accounts.request.dto.ts
+++ b/libs/types/src/dtos/account/accounts.request.dto.ts
@@ -14,5 +14,5 @@ export class RetireMsaRequestDto extends RetireMsaPayloadResponseDto {
 }
 
 export type PublishRetireMsaRequestDto = RetireMsaRequestDto & {
-  type: TransactionType.RETIRE_MSA;
+  type: typeof TransactionType.RETIRE_MSA;
 };

--- a/libs/types/src/dtos/account/graphs.request.dto.ts
+++ b/libs/types/src/dtos/account/graphs.request.dto.ts
@@ -117,7 +117,7 @@ export class AddNewPublicKeyAgreementPayloadRequest {
 }
 
 export type PublicKeyAgreementRequestDto = AddNewPublicKeyAgreementRequestDto & {
-  type: TransactionType.ADD_PUBLIC_KEY_AGREEMENT;
+  type: typeof TransactionType.ADD_PUBLIC_KEY_AGREEMENT;
 };
 
 export class PublicKeyAgreementsKeyPayload {

--- a/libs/types/src/dtos/account/handles.request.dto.ts
+++ b/libs/types/src/dtos/account/handles.request.dto.ts
@@ -61,11 +61,11 @@ export class ChangeHandlePayloadRequest {
 }
 
 export type CreateHandleRequest = HandleRequestDto & {
-  type: TransactionType.CREATE_HANDLE;
+  type: typeof TransactionType.CREATE_HANDLE;
 };
 
 export type ChangeHandleRequest = HandleRequestDto & {
-  type: TransactionType.CHANGE_HANDLE;
+  type: typeof TransactionType.CHANGE_HANDLE;
 };
 
 export type PublishHandleRequestDto = CreateHandleRequest | ChangeHandleRequest;

--- a/libs/types/src/dtos/account/ics.request.dto.ts
+++ b/libs/types/src/dtos/account/ics.request.dto.ts
@@ -87,4 +87,4 @@ export class IcsPublishAllRequestDto {
   addContentGroupMetadataPayload?: UpsertPagePayloadDto;
 }
 
-export type PublishIcsPublishAllRequestDto = IcsPublishAllRequestDto & { type: TransactionType.CAPACITY_BATCH };
+export type PublishIcsPublishAllRequestDto = IcsPublishAllRequestDto & { type: typeof TransactionType.CAPACITY_BATCH };

--- a/libs/types/src/dtos/account/keys.request.dto.ts
+++ b/libs/types/src/dtos/account/keys.request.dto.ts
@@ -65,7 +65,7 @@ export class KeysRequestDto {
 }
 
 export type AddKeyRequestDto = KeysRequestDto & {
-  type: TransactionType.ADD_KEY;
+  type: typeof TransactionType.ADD_KEY;
 };
 
 export type PublishKeysRequestDto = AddKeyRequestDto;

--- a/libs/types/src/dtos/account/revokeDelegation.request.dto.ts
+++ b/libs/types/src/dtos/account/revokeDelegation.request.dto.ts
@@ -46,5 +46,5 @@ export class RevokeDelegationPayloadRequestDto extends RevokeDelegationPayloadRe
 }
 
 export type PublishRevokeDelegationRequestDto = RevokeDelegationPayloadRequestDto & {
-  type: TransactionType.REVOKE_DELEGATION;
+  type: typeof TransactionType.REVOKE_DELEGATION;
 };

--- a/libs/types/src/dtos/account/transaction.request.dto.ts
+++ b/libs/types/src/dtos/account/transaction.request.dto.ts
@@ -1,5 +1,3 @@
-import { BlockHash } from '@polkadot/types/interfaces';
-import { HexString } from '@polkadot/util/types';
 import { PublishIcsPublishAllRequestDto } from './ics.request.dto';
 import { PublicKeyAgreementRequestDto } from './graphs.request.dto';
 import { PublishHandleRequestDto } from './handles.request.dto';
@@ -16,13 +14,13 @@ export interface EncodedExtrinsic {
 
 export type PublishSIWFSignupRequestDto = {
   calls: EncodedExtrinsic[];
-  type: TransactionType.SIWF_SIGNUP;
+  type: typeof TransactionType.SIWF_SIGNUP;
   authorizationCode?: string;
 };
 
 export type PublishCapacityBatchRequestDto = {
   calls: EncodedExtrinsic[];
-  type: TransactionType.CAPACITY_BATCH;
+  type: typeof TransactionType.CAPACITY_BATCH;
 };
 
 export type TransactionData<
@@ -38,11 +36,4 @@ export type TransactionData<
 > = RequestType & {
   providerId: string;
   referenceId: string;
-};
-
-export type TxMonitorJob = TransactionData & {
-  id: string;
-  txHash: HexString;
-  epoch: number;
-  lastFinalizedBlockHash: BlockHash;
 };

--- a/libs/types/src/tx-notification-webhook/index.ts
+++ b/libs/types/src/tx-notification-webhook/index.ts
@@ -24,8 +24,13 @@ export {
   type RevokeDelegationWebhookRsp,
   type SIWFOpts,
   type SIWFWebhookRsp,
+  TransactionStatus,
   TransactionType,
+  type TxWebhookExpiredRsp,
+  type TxWebhookFailureRsp,
   type TxWebhookOpts,
   type TxWebhookRsp,
   type TxWebhookRspBase,
+  type TxWebhookRspSuccessBase,
+  type TxWebhookSuccessRsp,
 } from './types.gen';

--- a/libs/types/src/tx-notification-webhook/types.gen.ts
+++ b/libs/types/src/tx-notification-webhook/types.gen.ts
@@ -68,7 +68,6 @@ export type TxWebhookRspBase = {
   referenceId: string;
   msaId?: string;
   txHash: string;
-  error?: string;
 };
 
 export type TxWebhookRspSuccessBase = TxWebhookRspBase & {
@@ -165,10 +164,12 @@ export type CapacityBatchAllWebhookRsp = TxWebhookRspSuccessBase &
 export type TxWebhookFailureRsp = TxWebhookRspBase & {
   status: 'FAILED';
   error: string;
+  transactionType: TransactionType;
 };
 
 export type TxWebhookExpiredRsp = TxWebhookRspBase & {
   status: 'EXPIRED';
+  transactionType: TransactionType;
 };
 
 export type TxWebhookSuccessRsp =

--- a/libs/types/src/tx-notification-webhook/types.gen.ts
+++ b/libs/types/src/tx-notification-webhook/types.gen.ts
@@ -4,6 +4,21 @@ export type ClientOptions = {
   baseURL: `${string}://${string}` | (string & {});
 };
 
+export enum TransactionStatus {
+  /**
+   * SUCCESS
+   */
+  SUCCESS = 'SUCCESS',
+  /**
+   * FAILED
+   */
+  FAILED = 'FAILED',
+  /**
+   * EXPIRED
+   */
+  EXPIRED = 'EXPIRED',
+}
+
 export enum TransactionType {
   /**
    * ON_CHAIN_CONTENT
@@ -53,6 +68,11 @@ export type TxWebhookRspBase = {
   referenceId: string;
   msaId?: string;
   txHash: string;
+  error?: string;
+};
+
+export type TxWebhookRspSuccessBase = TxWebhookRspBase & {
+  status: 'SUCCESS';
 };
 
 export type OnChainContentOpts = {
@@ -97,52 +117,61 @@ export type TxWebhookOpts =
   | PublishGraphKeysOpts
   | CapacityBatchAllOpts;
 
-export type CreateHandleWebhookRsp = TxWebhookRspBase &
+export type CreateHandleWebhookRsp = TxWebhookRspSuccessBase &
   PublishHandleOpts & {
     transactionType: 'CREATE_HANDLE';
   };
 
-export type OnChainContentWebhookRsp = TxWebhookRspBase &
+export type OnChainContentWebhookRsp = TxWebhookRspSuccessBase &
   OnChainContentOpts & {
     transactionType: 'ON_CHAIN_CONTENT';
   };
 
-export type ChangeHandleWebhookRsp = TxWebhookRspBase &
+export type ChangeHandleWebhookRsp = TxWebhookRspSuccessBase &
   PublishHandleOpts & {
     transactionType: 'CHANGE_HANDLE';
   };
 
 export type PublishHandleWebhookRsp = CreateHandleWebhookRsp | ChangeHandleWebhookRsp;
 
-export type SIWFWebhookRsp = TxWebhookRspBase &
+export type SIWFWebhookRsp = TxWebhookRspSuccessBase &
   SIWFOpts & {
     transactionType: 'SIWF_SIGNUP';
   };
 
-export type PublishKeysWebhookRsp = TxWebhookRspBase &
+export type PublishKeysWebhookRsp = TxWebhookRspSuccessBase &
   PublishKeysOpts & {
     transactionType: 'ADD_KEY';
   };
 
-export type PublishGraphKeysWebhookRsp = TxWebhookRspBase &
+export type PublishGraphKeysWebhookRsp = TxWebhookRspSuccessBase &
   PublishGraphKeysOpts & {
     transactionType: 'ADD_PUBLIC_KEY_AGREEMENT';
   };
 
-export type RetireMsaWebhookRsp = TxWebhookRspBase & {
+export type RetireMsaWebhookRsp = TxWebhookRspSuccessBase & {
   transactionType: 'RETIRE_MSA';
 };
 
-export type RevokeDelegationWebhookRsp = TxWebhookRspBase & {
+export type RevokeDelegationWebhookRsp = TxWebhookRspSuccessBase & {
   transactionType: 'REVOKE_DELEGATION';
 };
 
-export type CapacityBatchAllWebhookRsp = TxWebhookRspBase &
+export type CapacityBatchAllWebhookRsp = TxWebhookRspSuccessBase &
   CapacityBatchAllOpts & {
     transactionType: 'CAPACITY_BATCH';
   };
 
-export type TxWebhookRsp =
+export type TxWebhookFailureRsp = TxWebhookRspBase & {
+  status: 'FAILED';
+  error: string;
+};
+
+export type TxWebhookExpiredRsp = TxWebhookRspBase & {
+  status: 'EXPIRED';
+};
+
+export type TxWebhookSuccessRsp =
   | ({
       transactionType: 'ON_CHAIN_CONTENT';
     } & OnChainContentWebhookRsp)
@@ -170,6 +199,17 @@ export type TxWebhookRsp =
   | ({
       transactionType: 'CAPACITY_BATCH';
     } & CapacityBatchAllWebhookRsp);
+
+export type TxWebhookRsp =
+  | ({
+      status: 'SUCCESS';
+    } & TxWebhookSuccessRsp)
+  | ({
+      status: 'FAILED';
+    } & TxWebhookFailureRsp)
+  | ({
+      status: 'EXPIRED';
+    } & TxWebhookExpiredRsp);
 
 export type getHealthzData = {
   body?: never;

--- a/libs/types/src/tx-notification-webhook/types.gen.ts
+++ b/libs/types/src/tx-notification-webhook/types.gen.ts
@@ -4,63 +4,67 @@ export type ClientOptions = {
   baseURL: `${string}://${string}` | (string & {});
 };
 
-export enum TransactionStatus {
+export const TransactionStatus = {
   /**
    * SUCCESS
    */
-  SUCCESS = 'SUCCESS',
+  SUCCESS: 'SUCCESS',
   /**
    * FAILED
    */
-  FAILED = 'FAILED',
+  FAILED: 'FAILED',
   /**
    * EXPIRED
    */
-  EXPIRED = 'EXPIRED',
-}
+  EXPIRED: 'EXPIRED',
+} as const;
 
-export enum TransactionType {
+export type TransactionStatus = (typeof TransactionStatus)[keyof typeof TransactionStatus];
+
+export const TransactionType = {
   /**
    * ON_CHAIN_CONTENT
    */
-  ON_CHAIN_CONTENT = 'ON_CHAIN_CONTENT',
+  ON_CHAIN_CONTENT: 'ON_CHAIN_CONTENT',
   /**
    * CHANGE_HANDLE
    */
-  CHANGE_HANDLE = 'CHANGE_HANDLE',
+  CHANGE_HANDLE: 'CHANGE_HANDLE',
   /**
    * CREATE_HANDLE
    */
-  CREATE_HANDLE = 'CREATE_HANDLE',
+  CREATE_HANDLE: 'CREATE_HANDLE',
   /**
    * SIWF_SIGNUP
    */
-  SIWF_SIGNUP = 'SIWF_SIGNUP',
+  SIWF_SIGNUP: 'SIWF_SIGNUP',
   /**
    * SIWF_SIGNIN
    */
-  SIWF_SIGNIN = 'SIWF_SIGNIN',
+  SIWF_SIGNIN: 'SIWF_SIGNIN',
   /**
    * ADD_KEY
    */
-  ADD_KEY = 'ADD_KEY',
+  ADD_KEY: 'ADD_KEY',
   /**
    * RETIRE_MSA
    */
-  RETIRE_MSA = 'RETIRE_MSA',
+  RETIRE_MSA: 'RETIRE_MSA',
   /**
    * ADD_PUBLIC_KEY_AGREEMENT
    */
-  ADD_PUBLIC_KEY_AGREEMENT = 'ADD_PUBLIC_KEY_AGREEMENT',
+  ADD_PUBLIC_KEY_AGREEMENT: 'ADD_PUBLIC_KEY_AGREEMENT',
   /**
    * REVOKE_DELEGATION
    */
-  REVOKE_DELEGATION = 'REVOKE_DELEGATION',
+  REVOKE_DELEGATION: 'REVOKE_DELEGATION',
   /**
    * CAPACITY_BATCH
    */
-  CAPACITY_BATCH = 'CAPACITY_BATCH',
-}
+  CAPACITY_BATCH: 'CAPACITY_BATCH',
+} as const;
+
+export type TransactionType = (typeof TransactionType)[keyof typeof TransactionType];
 
 export type TxWebhookRspBase = {
   blockHash: string;
@@ -71,7 +75,7 @@ export type TxWebhookRspBase = {
 };
 
 export type TxWebhookRspSuccessBase = TxWebhookRspBase & {
-  status: 'SUCCESS';
+  status: TransactionStatus & 'SUCCESS';
 };
 
 export type OnChainContentOpts = {
@@ -162,13 +166,13 @@ export type CapacityBatchAllWebhookRsp = TxWebhookRspSuccessBase &
   };
 
 export type TxWebhookFailureRsp = TxWebhookRspBase & {
-  status: 'FAILED';
+  status: TransactionStatus & 'FAILED';
   error: string;
   transactionType: TransactionType;
 };
 
 export type TxWebhookExpiredRsp = TxWebhookRspBase & {
-  status: 'EXPIRED';
+  status: TransactionStatus & 'EXPIRED';
   transactionType: TransactionType;
 };
 

--- a/libs/webhooks/src/helpers/createWebhookRsp.helper.ts
+++ b/libs/webhooks/src/helpers/createWebhookRsp.helper.ts
@@ -26,7 +26,7 @@ import { IBaseTxStatus } from '#types/interfaces';
 export interface IBaseWebhookResponse extends IBaseTxStatus {
   msaId?: string;
   blockHash: string;
-  status: TransactionStatus;
+  status: typeof TransactionStatus.SUCCESS;
 }
 
 // Type guards

--- a/libs/webhooks/src/helpers/createWebhookRsp.helper.ts
+++ b/libs/webhooks/src/helpers/createWebhookRsp.helper.ts
@@ -19,12 +19,14 @@ import {
   RevokeDelegationWebhookRsp,
   CapacityBatchAllOpts,
   CapacityBatchAllWebhookRsp,
+  TransactionStatus,
 } from '#types/tx-notification-webhook';
 import { IBaseTxStatus } from '#types/interfaces';
 
 export interface IBaseWebhookResponse extends IBaseTxStatus {
   msaId?: string;
   blockHash: string;
+  status: TransactionStatus;
 }
 
 // Type guards
@@ -66,7 +68,7 @@ export function createWebhookRsp(
 export function createWebhookRsp(txStatus: IBaseWebhookResponse, options: PublishHandleOpts): PublishHandleWebhookRsp;
 export function createWebhookRsp(txStatus: IBaseWebhookResponse): RetireMsaWebhookRsp | RevokeDelegationWebhookRsp;
 export function createWebhookRsp(
-  { type: transactionType, providerId, referenceId, msaId, blockHash, txHash }: IBaseWebhookResponse,
+  { type: transactionType, providerId, referenceId, msaId, blockHash, txHash, status }: IBaseWebhookResponse,
   options?: TxWebhookOpts,
 ): TxWebhookRsp {
   const baseResponse = {
@@ -74,6 +76,7 @@ export function createWebhookRsp(
     referenceId,
     msaId,
     blockHash,
+    status,
     txHash,
     transactionType,
   };

--- a/openapi-specs/tx-notification-webhooks.openapi.yaml
+++ b/openapi-specs/tx-notification-webhooks.openapi.yaml
@@ -101,9 +101,11 @@ components:
           required: [status]
           properties:
             status:
-              type: string
-              enum:
-                - SUCCESS
+              allOf:
+                - $ref: '#/components/schemas/TransactionStatus'
+                - type: string
+                  enum:
+                    - SUCCESS
 
     OnChainContentOpts:
       type: object
@@ -331,9 +333,11 @@ components:
           required: [status, error, transactionType]
           properties:
             status:
-              type: string
-              enum:
-                - FAILED
+              allOf:
+                - $ref: '#/components/schemas/TransactionStatus'
+                - type: string
+                  enum:
+                    - FAILED
             error:
               type: string
             transactionType:
@@ -347,9 +351,11 @@ components:
           required: [status, transactionType]
           properties:
             status:
-              type: string
-              enum:
-                - EXPIRED
+              allOf:
+                - $ref: '#/components/schemas/TransactionStatus'
+                - type: string
+                  enum:
+                    - EXPIRED
             transactionType:
               $ref: '#/components/schemas/TransactionType'
 

--- a/openapi-specs/tx-notification-webhooks.openapi.yaml
+++ b/openapi-specs/tx-notification-webhooks.openapi.yaml
@@ -36,6 +36,17 @@ paths:
 
 components:
   schemas:
+    TransactionStatus:
+      type: string
+      enum:
+        - SUCCESS
+        - FAILED
+        - EXPIRED
+      x-enum-varnames:
+        - SUCCESS
+        - FAILED
+        - EXPIRED
+
     TransactionType:
       type: string
       enum:
@@ -81,6 +92,20 @@ components:
           type: string
         txHash:
           type: string
+        error:
+          type: string
+
+    TxWebhookRspSuccessBase:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - type: object
+          required: [status]
+          properties:
+            status:
+              type: string
+              enum:
+                - SUCCESS
 
     OnChainContentOpts:
       type: object
@@ -173,7 +198,7 @@ components:
     CreateHandleWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - $ref: '#/components/schemas/PublishHandleOpts'
         - type: object
           properties:
@@ -187,7 +212,7 @@ components:
     OnChainContentWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - $ref: '#/components/schemas/OnChainContentOpts'
         - type: object
           properties:
@@ -201,7 +226,7 @@ components:
     ChangeHandleWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - $ref: '#/components/schemas/PublishHandleOpts'
         - type: object
           properties:
@@ -221,7 +246,7 @@ components:
     SIWFWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - $ref: '#/components/schemas/SIWFOpts'
         - type: object
           properties:
@@ -235,7 +260,7 @@ components:
     PublishKeysWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - $ref: '#/components/schemas/PublishKeysOpts'
         - type: object
           properties:
@@ -249,7 +274,7 @@ components:
     PublishGraphKeysWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - $ref: '#/components/schemas/PublishGraphKeysOpts'
         - type: object
           properties:
@@ -263,7 +288,7 @@ components:
     RetireMsaWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - type: object
           properties:
             transactionType:
@@ -276,7 +301,7 @@ components:
     RevokeDelegationWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - type: object
           properties:
             transactionType:
@@ -289,7 +314,7 @@ components:
     CapacityBatchAllWebhookRsp:
       type: object
       allOf:
-        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - $ref: '#/components/schemas/TxWebhookRspSuccessBase'
         - $ref: '#/components/schemas/CapacityBatchAllOpts'
         - type: object
           properties:
@@ -300,7 +325,33 @@ components:
           required:
             - transactionType
 
-    TxWebhookRsp:
+    TxWebhookFailureRsp:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - type: object
+          required: [status, error]
+          properties:
+            status:
+              type: string
+              enum:
+                - FAILED
+            error:
+              type: string
+
+    TxWebhookExpiredRsp:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/TxWebhookRspBase'
+        - type: object
+          required: [status]
+          properties:
+            status:
+              type: string
+              enum:
+                - EXPIRED
+
+    TxWebhookSuccessRsp:
       discriminator:
         propertyName: transactionType
         mapping:
@@ -323,3 +374,15 @@ components:
         - $ref: '#/components/schemas/RetireMsaWebhookRsp'
         - $ref: '#/components/schemas/RevokeDelegationWebhookRsp'
         - $ref: '#/components/schemas/CapacityBatchAllWebhookRsp'
+
+    TxWebhookRsp:
+      discriminator:
+        propertyName: status
+        mapping:
+          SUCCESS: '#/components/schemas/TxWebhookSuccessRsp'
+          FAILED: '#/components/schemas/TxWebhookFailureRsp'
+          EXPIRED: '#/components/schemas/TxWebhookExpiredRsp'
+      oneOf:
+        - $ref: '#/components/schemas/TxWebhookSuccessRsp'
+        - $ref: '#/components/schemas/TxWebhookFailureRsp'
+        - $ref: '#/components/schemas/TxWebhookExpiredRsp'

--- a/openapi-specs/tx-notification-webhooks.openapi.yaml
+++ b/openapi-specs/tx-notification-webhooks.openapi.yaml
@@ -92,8 +92,6 @@ components:
           type: string
         txHash:
           type: string
-        error:
-          type: string
 
     TxWebhookRspSuccessBase:
       type: object
@@ -330,7 +328,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/TxWebhookRspBase'
         - type: object
-          required: [status, error]
+          required: [status, error, transactionType]
           properties:
             status:
               type: string
@@ -338,18 +336,22 @@ components:
                 - FAILED
             error:
               type: string
+            transactionType:
+              $ref: '#/components/schemas/TransactionType'
 
     TxWebhookExpiredRsp:
       type: object
       allOf:
         - $ref: '#/components/schemas/TxWebhookRspBase'
         - type: object
-          required: [status]
+          required: [status, transactionType]
           properties:
             status:
               type: string
               enum:
                 - EXPIRED
+            transactionType:
+              $ref: '#/components/schemas/TransactionType'
 
     TxWebhookSuccessRsp:
       discriminator:

--- a/openapi-ts.tx-notification-webhook.config.ts
+++ b/openapi-ts.tx-notification-webhook.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       name: '@hey-api/typescript',
       case: 'preserve',
       enums: {
-        mode: 'typescript',
+        mode: 'javascript',
         case: 'preserve',
       },
     },


### PR DESCRIPTION
# Purpose

The goal of this PR is to add failure and expiration webhook notifications to the `account-service-worker` and `content-publishing-worker`

### Change summary
- Update OpenAPI spec for webhook notifications to include:
    - transaction status `SUCCESS`, `FAILED`, `EXPIRED` for all notifications
    - add `error` message for `FAILED` cases
    - add specific request shapes for failure & expiration request payloads
- Regenerate types for webhook
- Small refactor of account & content-publishing notifiers to hoist webhook notification into its own function, which is called from the success, failure, and expired transaction handlers

### Checklist

Delete items that don't apply or mark Not Applicable

- [x] Unit tests added/updated
- [x] Integration/end-to-end tests added/updated
- ~[ ] Documentation added or updated (where applicable)~
- [x] API endpoints added or changed? Added the endpoints in main.ts and regenerated Swagger docs
- ~[ ] New packages are noted in the description or summary with what they do~
- ~[ ] Breaking changes? "breaking changes" label added.~
- ~[ ] Environment variable changes? This is a breaking change for deployment:~
  - ~[ ] Update docker files, files, environment templates~
  - ~[ ] Update config Joi validations, and config setup in tests~
  - ~[ ] Make a pull request for any \*-infra repositories with a deployed Gateway instance. Merge this _first_~
        ~before merging this PR.~
